### PR TITLE
Add Shopify credentials support

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/VendorController.java
+++ b/backend/src/main/java/com/rocket/service/controller/VendorController.java
@@ -11,6 +11,7 @@ import com.rocket.service.mapper.VendorMapper;
 import com.rocket.service.model.DBResponse;
 import com.rocket.service.model.VendorCatalogServiceOutDto;
 import com.rocket.service.model.VendorServiceDto;
+import com.rocket.service.model.VendorCredentialsDto;
 import com.rocket.service.service.SequenceGeneratorService;
 import com.rocket.service.service.UsuarioService;
 import com.rocket.service.service.VendorService;
@@ -60,9 +61,9 @@ public class VendorController {
 	}
 
 	@RequestMapping(value = "/vendor-catalog", method = RequestMethod.GET, produces = { "application/json;charset=UTF-8" })
-	public ResponseEntity<String> getVendorCatalog() {
-		List<VendorDto> vendorDtos = service.obtenerTiendas();
-		List<VendorCatalogServiceOutDto> response = new ArrayList<>();
+        public ResponseEntity<String> getVendorCatalog() {
+                List<VendorDto> vendorDtos = service.obtenerTiendas();
+                List<VendorCatalogServiceOutDto> response = new ArrayList<>();
 
 		vendorDtos.forEach(vendorDto -> {
 			VendorCatalogServiceOutDto vendorCatalogServiceOutDto = VendorMapper.mapVendorDtoToVendorCatalogServiceOutDto(vendorDto);
@@ -70,9 +71,31 @@ public class VendorController {
 		});
 
 		Gson gson = new Gson();
-		String json = gson.toJson(response);
-		return new ResponseEntity<>(json, HttpStatus.OK);
-	}
+                String json = gson.toJson(response);
+                return new ResponseEntity<>(json, HttpStatus.OK);
+        }
+
+        @RequestMapping(value = "/vendor/{id}/shopify", method = RequestMethod.GET, produces = { "application/json;charset=UTF-8" })
+        public ResponseEntity<String> obtenerCredencialesShopify(@PathVariable Integer id) {
+                VendorDto vendorDto = service.obtenerTiendaPorId(id);
+                VendorCredentialsDto cred = new VendorCredentialsDto();
+                cred.setShopifyApiKey(vendorDto.getShopifyApiKey());
+                cred.setShopifyAccessToken(vendorDto.getShopifyAccessToken());
+
+                Gson gson = new Gson();
+                String json = gson.toJson(cred);
+                return new ResponseEntity<>(json, HttpStatus.OK);
+        }
+
+        @RequestMapping(value = "/vendor/{id}/shopify", method = RequestMethod.PUT, produces = { "application/json;charset=UTF-8" })
+        public ResponseEntity<String> actualizarCredencialesShopify(@PathVariable Integer id, @RequestBody VendorCredentialsDto cred) {
+                VendorDto vendorDto = service.obtenerTiendaPorId(id);
+                service.actualizarCredencialesShopify(vendorDto, cred.getShopifyApiKey(), cred.getShopifyAccessToken());
+
+                Gson gson = new Gson();
+                String json = gson.toJson(new DBResponse(true, "Credenciales actualizadas"));
+                return new ResponseEntity<>(json, HttpStatus.OK);
+        }
 
 	@RequestMapping(value = "/vendor", method = RequestMethod.PUT, produces = { "application/json;charset=UTF-8" })
 	public ResponseEntity<String> actualizarTienda(@RequestBody VendorServiceDto vendorServiceInDto) {

--- a/backend/src/main/java/com/rocket/service/entity/VendorDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/VendorDto.java
@@ -25,9 +25,11 @@ public class VendorDto {
 	private String canalVenta;
 	private String preferenciaPagoFactura;
 	private String sitio;
-	private String email;
-	private String telefono;
-	private Binary logo;
+        private String email;
+        private String telefono;
+        private String shopifyApiKey;
+        private String shopifyAccessToken;
+        private Binary logo;
     private Boolean activo;
 
     /**
@@ -182,6 +184,22 @@ public class VendorDto {
      */
     public void setTelefono(String telefono) {
         this.telefono = telefono;
+    }
+
+    public String getShopifyApiKey() {
+        return shopifyApiKey;
+    }
+
+    public void setShopifyApiKey(String shopifyApiKey) {
+        this.shopifyApiKey = shopifyApiKey;
+    }
+
+    public String getShopifyAccessToken() {
+        return shopifyAccessToken;
+    }
+
+    public void setShopifyAccessToken(String shopifyAccessToken) {
+        this.shopifyAccessToken = shopifyAccessToken;
     }
 
     /**

--- a/backend/src/main/java/com/rocket/service/mapper/VendorMapper.java
+++ b/backend/src/main/java/com/rocket/service/mapper/VendorMapper.java
@@ -24,6 +24,8 @@ public class VendorMapper {
         vendorServiceOutDto.setSitio(vendorDto.getSitio());
         vendorServiceOutDto.setEmail(vendorDto.getEmail());
         vendorServiceOutDto.setTelefono(vendorDto.getTelefono());
+        vendorServiceOutDto.setShopifyApiKey(vendorDto.getShopifyApiKey());
+        vendorServiceOutDto.setShopifyAccessToken(vendorDto.getShopifyAccessToken());
         vendorServiceOutDto.setActivo(vendorDto.isActivo());
         vendorServiceOutDto.setDireccionCompleta(vendorDto.getDireccionCompleta());
         vendorServiceOutDto.setDireccion(vendorDto.getDireccion());
@@ -48,6 +50,8 @@ public class VendorMapper {
         vendorDto.setSitio(vendorServiceDto.getSitio());
         vendorDto.setEmail(vendorServiceDto.getEmail());
         vendorDto.setTelefono(vendorServiceDto.getTelefono());
+        vendorDto.setShopifyApiKey(vendorServiceDto.getShopifyApiKey());
+        vendorDto.setShopifyAccessToken(vendorServiceDto.getShopifyAccessToken());
         vendorDto.setActivo(vendorServiceDto.isActivo());
         vendorDto.setDireccionCompleta(vendorServiceDto.getDireccionCompleta());
         if(vendorServiceDto.getDireccionCompleta() != null)

--- a/backend/src/main/java/com/rocket/service/model/VendorCredentialsDto.java
+++ b/backend/src/main/java/com/rocket/service/model/VendorCredentialsDto.java
@@ -1,0 +1,23 @@
+package com.rocket.service.model;
+
+public class VendorCredentialsDto {
+
+    private String shopifyApiKey;
+    private String shopifyAccessToken;
+
+    public String getShopifyApiKey() {
+        return shopifyApiKey;
+    }
+
+    public void setShopifyApiKey(String shopifyApiKey) {
+        this.shopifyApiKey = shopifyApiKey;
+    }
+
+    public String getShopifyAccessToken() {
+        return shopifyAccessToken;
+    }
+
+    public void setShopifyAccessToken(String shopifyAccessToken) {
+        this.shopifyAccessToken = shopifyAccessToken;
+    }
+}

--- a/backend/src/main/java/com/rocket/service/model/VendorServiceDto.java
+++ b/backend/src/main/java/com/rocket/service/model/VendorServiceDto.java
@@ -15,8 +15,10 @@ public class VendorServiceDto {
 	private String preferenciaPagoFactura;
 	private String sitio;
 	private String email;
-	private String telefono;
-	private String logo;
+        private String telefono;
+        private String shopifyApiKey;
+        private String shopifyAccessToken;
+        private String logo;
     private Boolean activo;
 
     /**
@@ -171,6 +173,22 @@ public class VendorServiceDto {
      */
     public void setTelefono(String telefono) {
         this.telefono = telefono;
+    }
+
+    public String getShopifyApiKey() {
+        return shopifyApiKey;
+    }
+
+    public void setShopifyApiKey(String shopifyApiKey) {
+        this.shopifyApiKey = shopifyApiKey;
+    }
+
+    public String getShopifyAccessToken() {
+        return shopifyAccessToken;
+    }
+
+    public void setShopifyAccessToken(String shopifyAccessToken) {
+        this.shopifyAccessToken = shopifyAccessToken;
     }
 
     /**

--- a/backend/src/main/java/com/rocket/service/service/VendorService.java
+++ b/backend/src/main/java/com/rocket/service/service/VendorService.java
@@ -61,10 +61,17 @@ public class VendorService {
 		return tiendas;
 	}
 
-	public VendorDto setActivo(VendorDto tienda, Boolean activo){		
-		tienda.setActivo(activo);
+        public VendorDto setActivo(VendorDto tienda, Boolean activo){
+                tienda.setActivo(activo);
 
-		return vendorRepository.save(tienda);
-	}
+                return vendorRepository.save(tienda);
+        }
+
+        public VendorDto actualizarCredencialesShopify(VendorDto tienda, String apiKey, String accessToken){
+                tienda.setShopifyApiKey(apiKey);
+                tienda.setShopifyAccessToken(accessToken);
+
+                return vendorRepository.save(tienda);
+        }
 
 }

--- a/frontend/src/app/models/tienda.model.ts
+++ b/frontend/src/app/models/tienda.model.ts
@@ -12,6 +12,8 @@ export class Tienda {
   preferenciaPagoFactura?: string;
   email?: string;
   telefono?: string;
+  shopifyApiKey?: string;
+  shopifyAccessToken?: string;
   activo: boolean;
   logo?: any;
 
@@ -32,6 +34,8 @@ export class Tienda {
     if (tienda.preferenciaPagoFactura) this.preferenciaPagoFactura = tienda.preferenciaPagoFactura;
     if (tienda.email) this.email = tienda.email;
     if (tienda.telefono) this.telefono = tienda.telefono;
+    if (tienda.shopifyApiKey) this.shopifyApiKey = tienda.shopifyApiKey;
+    if (tienda.shopifyAccessToken) this.shopifyAccessToken = tienda.shopifyAccessToken;
     if (tienda.activo) this.activo = tienda.activo;
     if (tienda.logo) this.logo = tienda.logo;
   }

--- a/frontend/src/app/services/tienda.service.ts
+++ b/frontend/src/app/services/tienda.service.ts
@@ -35,6 +35,16 @@ export class TiendaService {
     return this.http.put(url, tienda, this.getOptions());
   }
 
+  obtenerCredencialesShopify(idTienda: number) {
+    const url = this.URL_SERVICIOS + '/vendor/' + idTienda + '/shopify';
+    return this.http.get(url, this.getOptions());
+  }
+
+  actualizarCredencialesShopify(idTienda: number, cred: any) {
+    const url = this.URL_SERVICIOS + '/vendor/' + idTienda + '/shopify';
+    return this.http.put(url, cred, this.getOptions());
+  }
+
 
   crearTienda(tienda: Tienda) {
 


### PR DESCRIPTION
## Summary
- extend `VendorDto` with Shopify credential fields
- map new fields to service DTO and Angular models
- expose GET/PUT endpoints to manage credentials
- add Angular service methods for Shopify credentials

## Testing
- `npm --version`
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686273a80620832398d0f8d8a11a247d