### PR TITLE
Limit config menu to vendor role

### DIFF
--- a/frontend/src/app/pages/pages-menu.ts
+++ b/frontend/src/app/pages/pages-menu.ts
@@ -64,15 +64,15 @@ export const admin_menu: NbMenuItem[] = [
         },
       }
       ,
-      {
-        title: 'Configuración',
-        icon: 'settings-outline',
-        link: '/intranet/configuracion',
-        data: {
-          permission: 'menu',
-          resource: ['admin']
-        },
-      }
     ]
+  },
+  {
+    title: 'Configuración',
+    icon: 'settings-outline',
+    link: '/intranet/configuracion',
+    data: {
+      permission: 'menu',
+      resource: ['customer']
+    },
   },
 ];

--- a/frontend/src/app/pages/pages-routing.module.ts
+++ b/frontend/src/app/pages/pages-routing.module.ts
@@ -55,7 +55,7 @@ const routes: Routes = [{
       component: ConfiguracionComponent,
       canActivate: [AuthGuard],
       data: {
-        resource: ['admin'],
+        resource: ['customer'],
       },
     },
     {


### PR DESCRIPTION
## Summary
- only show the Configuración option to vendor users
- gate the Configuración route behind the `customer` role

## Testing
- `npm test` *(fails: ng not found)*
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68627e51775083239c61b3b9a021eb7a