### PR TITLE
Limit config menu to vendor role

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/VendorController.java
+++ b/backend/src/main/java/com/rocket/service/controller/VendorController.java
@@ -81,6 +81,7 @@ public class VendorController {
                 VendorCredentialsDto cred = new VendorCredentialsDto();
                 cred.setShopifyApiKey(vendorDto.getShopifyApiKey());
                 cred.setShopifyAccessToken(vendorDto.getShopifyAccessToken());
+                cred.setShopifyStoreUrl(vendorDto.getShopifyStoreUrl());
 
                 Gson gson = new Gson();
                 String json = gson.toJson(cred);
@@ -90,7 +91,7 @@ public class VendorController {
         @RequestMapping(value = "/vendor/{id}/shopify", method = RequestMethod.PUT, produces = { "application/json;charset=UTF-8" })
         public ResponseEntity<String> actualizarCredencialesShopify(@PathVariable Integer id, @RequestBody VendorCredentialsDto cred) {
                 VendorDto vendorDto = service.obtenerTiendaPorId(id);
-                service.actualizarCredencialesShopify(vendorDto, cred.getShopifyApiKey(), cred.getShopifyAccessToken());
+                service.actualizarCredencialesShopify(vendorDto, cred.getShopifyApiKey(), cred.getShopifyAccessToken(), cred.getShopifyStoreUrl());
 
                 Gson gson = new Gson();
                 String json = gson.toJson(new DBResponse(true, "Credenciales actualizadas"));

--- a/backend/src/main/java/com/rocket/service/entity/VendorDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/VendorDto.java
@@ -29,6 +29,7 @@ public class VendorDto {
         private String telefono;
         private String shopifyApiKey;
         private String shopifyAccessToken;
+        private String shopifyStoreUrl;
         private Binary logo;
     private Boolean activo;
 
@@ -200,6 +201,14 @@ public class VendorDto {
 
     public void setShopifyAccessToken(String shopifyAccessToken) {
         this.shopifyAccessToken = shopifyAccessToken;
+    }
+
+    public String getShopifyStoreUrl() {
+        return shopifyStoreUrl;
+    }
+
+    public void setShopifyStoreUrl(String shopifyStoreUrl) {
+        this.shopifyStoreUrl = shopifyStoreUrl;
     }
 
     /**

--- a/backend/src/main/java/com/rocket/service/mapper/VendorMapper.java
+++ b/backend/src/main/java/com/rocket/service/mapper/VendorMapper.java
@@ -26,6 +26,7 @@ public class VendorMapper {
         vendorServiceOutDto.setTelefono(vendorDto.getTelefono());
         vendorServiceOutDto.setShopifyApiKey(vendorDto.getShopifyApiKey());
         vendorServiceOutDto.setShopifyAccessToken(vendorDto.getShopifyAccessToken());
+        vendorServiceOutDto.setShopifyStoreUrl(vendorDto.getShopifyStoreUrl());
         vendorServiceOutDto.setActivo(vendorDto.isActivo());
         vendorServiceOutDto.setDireccionCompleta(vendorDto.getDireccionCompleta());
         vendorServiceOutDto.setDireccion(vendorDto.getDireccion());
@@ -52,6 +53,7 @@ public class VendorMapper {
         vendorDto.setTelefono(vendorServiceDto.getTelefono());
         vendorDto.setShopifyApiKey(vendorServiceDto.getShopifyApiKey());
         vendorDto.setShopifyAccessToken(vendorServiceDto.getShopifyAccessToken());
+        vendorDto.setShopifyStoreUrl(vendorServiceDto.getShopifyStoreUrl());
         vendorDto.setActivo(vendorServiceDto.isActivo());
         vendorDto.setDireccionCompleta(vendorServiceDto.getDireccionCompleta());
         if(vendorServiceDto.getDireccionCompleta() != null)

--- a/backend/src/main/java/com/rocket/service/model/VendorCredentialsDto.java
+++ b/backend/src/main/java/com/rocket/service/model/VendorCredentialsDto.java
@@ -4,6 +4,7 @@ public class VendorCredentialsDto {
 
     private String shopifyApiKey;
     private String shopifyAccessToken;
+    private String shopifyStoreUrl;
 
     public String getShopifyApiKey() {
         return shopifyApiKey;
@@ -19,5 +20,13 @@ public class VendorCredentialsDto {
 
     public void setShopifyAccessToken(String shopifyAccessToken) {
         this.shopifyAccessToken = shopifyAccessToken;
+    }
+
+    public String getShopifyStoreUrl() {
+        return shopifyStoreUrl;
+    }
+
+    public void setShopifyStoreUrl(String shopifyStoreUrl) {
+        this.shopifyStoreUrl = shopifyStoreUrl;
     }
 }

--- a/backend/src/main/java/com/rocket/service/model/VendorServiceDto.java
+++ b/backend/src/main/java/com/rocket/service/model/VendorServiceDto.java
@@ -14,10 +14,11 @@ public class VendorServiceDto {
 	private String canalVenta;
 	private String preferenciaPagoFactura;
 	private String sitio;
-	private String email;
+        private String email;
         private String telefono;
         private String shopifyApiKey;
         private String shopifyAccessToken;
+        private String shopifyStoreUrl;
         private String logo;
     private Boolean activo;
 
@@ -189,6 +190,14 @@ public class VendorServiceDto {
 
     public void setShopifyAccessToken(String shopifyAccessToken) {
         this.shopifyAccessToken = shopifyAccessToken;
+    }
+
+    public String getShopifyStoreUrl() {
+        return shopifyStoreUrl;
+    }
+
+    public void setShopifyStoreUrl(String shopifyStoreUrl) {
+        this.shopifyStoreUrl = shopifyStoreUrl;
     }
 
     /**

--- a/backend/src/main/java/com/rocket/service/service/VendorService.java
+++ b/backend/src/main/java/com/rocket/service/service/VendorService.java
@@ -67,9 +67,10 @@ public class VendorService {
                 return vendorRepository.save(tienda);
         }
 
-        public VendorDto actualizarCredencialesShopify(VendorDto tienda, String apiKey, String accessToken){
+        public VendorDto actualizarCredencialesShopify(VendorDto tienda, String apiKey, String accessToken, String storeUrl){
                 tienda.setShopifyApiKey(apiKey);
                 tienda.setShopifyAccessToken(accessToken);
+                tienda.setShopifyStoreUrl(storeUrl);
 
                 return vendorRepository.save(tienda);
         }

--- a/frontend/src/app/models/tienda.model.ts
+++ b/frontend/src/app/models/tienda.model.ts
@@ -14,6 +14,7 @@ export class Tienda {
   telefono?: string;
   shopifyApiKey?: string;
   shopifyAccessToken?: string;
+  shopifyStoreUrl?: string;
   activo: boolean;
   logo?: any;
 
@@ -36,6 +37,7 @@ export class Tienda {
     if (tienda.telefono) this.telefono = tienda.telefono;
     if (tienda.shopifyApiKey) this.shopifyApiKey = tienda.shopifyApiKey;
     if (tienda.shopifyAccessToken) this.shopifyAccessToken = tienda.shopifyAccessToken;
+    if (tienda.shopifyStoreUrl) this.shopifyStoreUrl = tienda.shopifyStoreUrl;
     if (tienda.activo) this.activo = tienda.activo;
     if (tienda.logo) this.logo = tienda.logo;
   }

--- a/frontend/src/app/pages/configuracion/configuracion.component.html
+++ b/frontend/src/app/pages/configuracion/configuracion.component.html
@@ -10,6 +10,10 @@
         <label for="accessToken" class="label">Access Token</label>
         <input nbInput fullWidth id="accessToken" name="accessToken" [(ngModel)]="accessToken" />
       </div>
+      <div class="form-group">
+        <label for="storeUrl" class="label">Store URL</label>
+        <input nbInput fullWidth id="storeUrl" name="storeUrl" [(ngModel)]="storeUrl" />
+      </div>
       <button nbButton status="primary" type="submit" [disabled]="saving">Guardar</button>
     </form>
   </nb-card-body>

--- a/frontend/src/app/pages/configuracion/configuracion.component.ts
+++ b/frontend/src/app/pages/configuracion/configuracion.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { NbAuthOAuth2JWTToken, NbAuthService } from '@nebular/auth';
 import { TiendaService } from '../../services/tienda.service';
+import { UsuarioService } from 'src/app/services/usuario.service';
+import { UsuarioCompleto } from 'src/app/models/usuario-completo.model';
 
 @Component({
   selector: 'app-configuracion',
@@ -9,20 +12,46 @@ import { TiendaService } from '../../services/tienda.service';
 export class ConfiguracionComponent implements OnInit {
   apiKey: string = '';
   accessToken: string = '';
+  storeUrl: string = '';
   saving = false;
+  vendorId?: number;
 
-  constructor(private tiendaService: TiendaService) {}
+  constructor(
+    private tiendaService: TiendaService,
+    private authService: NbAuthService,
+    private usuarioService: UsuarioService
+  ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.authService.getToken().subscribe((token: NbAuthOAuth2JWTToken) => {
+      if (token.isValid()) {
+        const payload: any = token.getAccessTokenPayload();
+        const username = payload.user_name;
+        this.usuarioService.obtenerUsuarioCompleto(username).subscribe(
+          (user: UsuarioCompleto) => {
+            this.vendorId = user.tienda;
+          },
+          (err) => {
+            console.error('No se pudo obtener el ID de la tienda', err);
+            this.vendorId = undefined;
+          }
+        );
+      }
+    });
+  }
 
   guardar() {
+    if (!this.vendorId) {
+      console.error('Vendor ID no disponible');
+      return;
+    }
     this.saving = true;
     const cred = {
       shopifyApiKey: this.apiKey,
-      shopifyAccessToken: this.accessToken
+      shopifyAccessToken: this.accessToken,
+      shopifyStoreUrl: this.storeUrl
     };
-    // Por simplicidad se asume id 1. En un caso real podría obtenerse de otra fuente
-    this.tiendaService.actualizarCredencialesShopify(1, cred).subscribe(
+    this.tiendaService.actualizarCredencialesShopify(this.vendorId, cred).subscribe(
       () => (this.saving = false),
       () => (this.saving = false)
     );

--- a/frontend/src/app/pages/pages-menu.ts
+++ b/frontend/src/app/pages/pages-menu.ts
@@ -64,15 +64,15 @@ export const admin_menu: NbMenuItem[] = [
         },
       }
       ,
-      {
-        title: 'Configuración',
-        icon: 'settings-outline',
-        link: '/intranet/configuracion',
-        data: {
-          permission: 'menu',
-          resource: ['admin']
-        },
-      }
     ]
+  },
+  {
+    title: 'Configuración',
+    icon: 'settings-outline',
+    link: '/intranet/configuracion',
+    data: {
+      permission: 'menu',
+      resource: ['customer']
+    },
   },
 ];

--- a/frontend/src/app/pages/pages-routing.module.ts
+++ b/frontend/src/app/pages/pages-routing.module.ts
@@ -55,7 +55,7 @@ const routes: Routes = [{
       component: ConfiguracionComponent,
       canActivate: [AuthGuard],
       data: {
-        resource: ['admin'],
+        resource: ['customer'],
       },
     },
     {


### PR DESCRIPTION
## Summary
- only show the Configuración option to vendor users
- gate the Configuración route behind the `customer` role
- store Shopify store URL along with credentials
- allow editing the store URL in Configuración
- fetch the current user's vendor id and use it when saving Shopify credentials

## Testing
- `npm test --silent` *(fails: ng not found)*
- `./mvnw -q test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68627e51775083239c61b3b9a021eb7a