### PR TITLE
Add notifications for credential update

### DIFF
--- a/frontend/src/app/pages/configuracion/configuracion.component.spec.ts
+++ b/frontend/src/app/pages/configuracion/configuracion.component.spec.ts
@@ -1,25 +1,72 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { of, throwError } from 'rxjs';
+import { NbToastrService } from '@nebular/theme';
+import { NbAuthService } from '@nebular/auth';
 import { ConfiguracionComponent } from './configuracion.component';
+import { TiendaService } from '../../services/tienda.service';
+import { UsuarioService } from 'src/app/services/usuario.service';
+
+class TiendaServiceStub {
+  actualizarCredencialesShopify() {
+    return of({});
+  }
+}
+
+class ToastrServiceStub {
+  success(message?: string, title?: string) {}
+  danger(message?: string, title?: string) {}
+}
 
 describe('ConfiguracionComponent', () => {
   let component: ConfiguracionComponent;
   let fixture: ComponentFixture<ConfiguracionComponent>;
+  let tiendaService: TiendaServiceStub;
+  let toastrService: ToastrServiceStub;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ ConfiguracionComponent ]
-    })
-    .compileComponents();
-  });
+    tiendaService = new TiendaServiceStub();
+    toastrService = new ToastrServiceStub();
 
-  beforeEach(() => {
+    await TestBed.configureTestingModule({
+      declarations: [ConfiguracionComponent],
+      providers: [
+        { provide: TiendaService, useValue: tiendaService },
+        {
+          provide: NbAuthService,
+          useValue: { getToken: () => of({ isValid: () => false }) },
+        },
+        { provide: UsuarioService, useValue: {} },
+        { provide: NbToastrService, useValue: toastrService },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(ConfiguracionComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should show success message on guardar success', () => {
+    const spy = spyOn(tiendaService, 'actualizarCredencialesShopify').and.returnValue(of({}));
+    const toastSpy = spyOn(toastrService, 'success');
+    component.vendorId = 1;
+    component.guardar();
+    expect(spy).toHaveBeenCalled();
+    expect(toastSpy).toHaveBeenCalled();
+    expect(component.saving).toBeFalse();
+  });
+
+  it('should show error message on guardar failure', () => {
+    spyOn(tiendaService, 'actualizarCredencialesShopify').and.returnValue(throwError(() => new Error('fail')));
+    const toastSpy = spyOn(toastrService, 'danger');
+    const logSpy = spyOn(console, 'error');
+    component.vendorId = 1;
+    component.guardar();
+    expect(toastSpy).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+    expect(component.saving).toBeFalse();
   });
 });

--- a/frontend/src/app/pages/configuracion/configuracion.component.ts
+++ b/frontend/src/app/pages/configuracion/configuracion.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NbAuthOAuth2JWTToken, NbAuthService } from '@nebular/auth';
+import { NbToastrService } from '@nebular/theme';
 import { TiendaService } from '../../services/tienda.service';
 import { UsuarioService } from 'src/app/services/usuario.service';
 import { UsuarioCompleto } from 'src/app/models/usuario-completo.model';
@@ -19,7 +20,8 @@ export class ConfiguracionComponent implements OnInit {
   constructor(
     private tiendaService: TiendaService,
     private authService: NbAuthService,
-    private usuarioService: UsuarioService
+    private usuarioService: UsuarioService,
+    private toastrService: NbToastrService
   ) {}
 
   ngOnInit(): void {
@@ -51,9 +53,24 @@ export class ConfiguracionComponent implements OnInit {
       shopifyAccessToken: this.accessToken,
       shopifyStoreUrl: this.storeUrl
     };
-    this.tiendaService.actualizarCredencialesShopify(this.vendorId, cred).subscribe(
-      () => (this.saving = false),
-      () => (this.saving = false)
-    );
+    this.tiendaService
+      .actualizarCredencialesShopify(this.vendorId, cred)
+      .subscribe(
+        () => {
+          this.toastrService.success(
+            'Credenciales actualizadas correctamente',
+            'Actualización'
+          );
+          this.saving = false;
+        },
+        (err) => {
+          console.error('Error actualizando credenciales', err);
+          this.toastrService.danger(
+            'No se pudieron actualizar las credenciales',
+            'Actualización'
+          );
+          this.saving = false;
+        }
+      );
   }
 }


### PR DESCRIPTION
## Summary
- show toastr messages when shop credentials are saved
- log HTTP errors when saving credentials fails
- cover success and failure cases in tests

## Testing
- `npm test --silent` *(fails: Chrome not found and OpenSSL error)*

------
https://chatgpt.com/codex/tasks/task_e_686732eb99c48323b285cdec72f002d8