### PR TITLE
Add date filters for Shopify orders

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -28,8 +28,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 public class ShopifyController {
@@ -41,7 +43,10 @@ public class ShopifyController {
     UsuarioService usuarioService;
 
     @RequestMapping(value = "/shopify/orders/{user}", method = RequestMethod.GET, produces = { "application/json;charset=UTF-8" })
-    public ResponseEntity<String> obtenerOrders(@PathVariable String user) {
+    public ResponseEntity<String> obtenerOrders(
+            @PathVariable String user,
+            @RequestParam(required = false) String created_at_min,
+            @RequestParam(required = false) String created_at_max) {
         Gson gson = new Gson();
         try {
 
@@ -58,8 +63,16 @@ public class ShopifyController {
             RestTemplate rest = new RestTemplate();
             HttpHeaders headers = new HttpHeaders();
             headers.add("X-Shopify-Access-Token", vendor.getShopifyAccessToken());
+            String url = "https://" + vendor.getSitio() + "/admin/api/2023-07/orders.json";
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
+            if (created_at_min != null) {
+                builder.queryParam("created_at_min", created_at_min);
+            }
+            if (created_at_max != null) {
+                builder.queryParam("created_at_max", created_at_max);
+            }
             ResponseEntity<String> resp = rest.exchange(
-                    "https://" + vendor.getSitio() + "/admin/api/2023-07/orders.json",
+                    builder.toUriString(),
                     HttpMethod.GET,
                     new HttpEntity<>(headers),
                     String.class);

--- a/frontend/src/app/pages/carga-layout/carga-layout.component.html
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.html
@@ -1,5 +1,13 @@
 <nb-card>
   <nb-card-body style="padding: 50px;">
+    <div class="row mb-3">
+      <div class="col">
+        <input nbInput type="date" placeholder="Fecha inicio" [(ngModel)]="fechaInicio" />
+      </div>
+      <div class="col">
+        <input nbInput type="date" placeholder="Fecha fin" [(ngModel)]="fechaFin" />
+      </div>
+    </div>
     <button nbButton status="primary" (click)="cargarMisEnvios()" class="mb-4">
       Cargar mis envíos
     </button>

--- a/frontend/src/app/pages/carga-layout/carga-layout.component.ts
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.ts
@@ -15,6 +15,9 @@ export class CargaLayoutComponent implements OnInit {
 
   user: any;
 
+  fechaInicio: string;
+  fechaFin: string;
+
   constructor(private shopifyService: ShopifyService, private authService: NbAuthService) { }
 
   ngOnInit(): void {
@@ -56,7 +59,9 @@ export class CargaLayoutComponent implements OnInit {
       return;
     }
     const vendor = this.user.user_name || this.user;
-    this.shopifyService.obtenerOrders(vendor).subscribe((data: any) => {
+    const inicio = this.fechaInicio ? new Date(this.fechaInicio).toISOString() : undefined;
+    const fin = this.fechaFin ? new Date(this.fechaFin).toISOString() : undefined;
+    this.shopifyService.obtenerOrders(vendor, inicio, fin).subscribe((data: any) => {
       if (this.previsualizacion) {
         this.previsualizacion.registerTest(JSON.stringify(data));
       }

--- a/frontend/src/app/services/shopify.service.ts
+++ b/frontend/src/app/services/shopify.service.ts
@@ -10,8 +10,22 @@ export class ShopifyService {
 
   constructor(private http: HttpClient) {}
 
-  obtenerOrders(vendor: string | number) {
-    const url = this.URL_SERVICIOS + '/shopify/orders/' + vendor;
+  obtenerOrders(
+    vendor: string | number,
+    created_at_min?: string,
+    created_at_max?: string
+  ) {
+    let url = this.URL_SERVICIOS + '/shopify/orders/' + vendor;
+    const params = [] as string[];
+    if (created_at_min) {
+      params.push('created_at_min=' + encodeURIComponent(created_at_min));
+    }
+    if (created_at_max) {
+      params.push('created_at_max=' + encodeURIComponent(created_at_max));
+    }
+    if (params.length) {
+      url += '?' + params.join('&');
+    }
     const options = { headers: this.getHeaders() };
     return this.http.get(url, options);
   }


### PR DESCRIPTION
## Summary
- allow optional `created_at_min` and `created_at_max` parameters when requesting Shopify orders
- build Shopify URL with query parameters in backend
- extend Shopify service to send optional dates
- add date fields to Carga Layout page and pass them when fetching orders

## Testing
- `mvn test` *(fails: `mvn` not found)*
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4bca23788323a2e534f2a44aeffc