### PR TITLE
Fix Shopify order query params

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -28,8 +28,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 public class ShopifyController {
@@ -41,7 +43,10 @@ public class ShopifyController {
     UsuarioService usuarioService;
 
     @RequestMapping(value = "/shopify/orders/{user}", method = RequestMethod.GET, produces = { "application/json;charset=UTF-8" })
-    public ResponseEntity<String> obtenerOrders(@PathVariable String user) {
+    public ResponseEntity<String> obtenerOrders(
+            @PathVariable String user,
+            @RequestParam(value = "created_at_min", required = false) String createdAtMin,
+            @RequestParam(value = "created_at_max", required = false) String createdAtMax) {
         Gson gson = new Gson();
         try {
 
@@ -58,8 +63,16 @@ public class ShopifyController {
             RestTemplate rest = new RestTemplate();
             HttpHeaders headers = new HttpHeaders();
             headers.add("X-Shopify-Access-Token", vendor.getShopifyAccessToken());
+            String url = "https://" + vendor.getSitio() + "/admin/api/2023-07/orders.json";
+            UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
+            if (createdAtMin != null && !createdAtMin.isBlank()) {
+                builder.queryParam("created_at_min", createdAtMin);
+            }
+            if (createdAtMax != null && !createdAtMax.isBlank()) {
+                builder.queryParam("created_at_max", createdAtMax);
+            }
             ResponseEntity<String> resp = rest.exchange(
-                    "https://" + vendor.getSitio() + "/admin/api/2023-07/orders.json",
+                    builder.toUriString(),
                     HttpMethod.GET,
                     new HttpEntity<>(headers),
                     String.class);

--- a/frontend/src/app/pages/carga-layout/carga-layout.component.html
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.html
@@ -1,5 +1,13 @@
 <nb-card>
   <nb-card-body style="padding: 50px;">
+    <div class="row mb-3">
+      <div class="col">
+        <input nbInput type="date" placeholder="Fecha inicio" [(ngModel)]="fechaInicio" />
+      </div>
+      <div class="col">
+        <input nbInput type="date" placeholder="Fecha fin" [(ngModel)]="fechaFin" />
+      </div>
+    </div>
     <button nbButton status="primary" (click)="cargarMisEnvios()" class="mb-4">
       Cargar mis envíos
     </button>

--- a/frontend/src/app/pages/carga-layout/carga-layout.component.ts
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.ts
@@ -15,6 +15,9 @@ export class CargaLayoutComponent implements OnInit {
 
   user: any;
 
+  fechaInicio: string;
+  fechaFin: string;
+
   constructor(private shopifyService: ShopifyService, private authService: NbAuthService) { }
 
   ngOnInit(): void {
@@ -56,7 +59,9 @@ export class CargaLayoutComponent implements OnInit {
       return;
     }
     const vendor = this.user.user_name || this.user;
-    this.shopifyService.obtenerOrders(vendor).subscribe((data: any) => {
+    const inicio = this.fechaInicio ? new Date(this.fechaInicio).toISOString() : undefined;
+    const fin = this.fechaFin ? new Date(this.fechaFin).toISOString() : undefined;
+    this.shopifyService.obtenerOrders(vendor, inicio, fin).subscribe((data: any) => {
       if (this.previsualizacion) {
         this.previsualizacion.registerTest(JSON.stringify(data));
       }

--- a/frontend/src/app/services/shopify.service.ts
+++ b/frontend/src/app/services/shopify.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
@@ -10,9 +10,20 @@ export class ShopifyService {
 
   constructor(private http: HttpClient) {}
 
-  obtenerOrders(vendor: string | number) {
+  obtenerOrders(
+    vendor: string | number,
+    created_at_min?: string,
+    created_at_max?: string
+  ) {
     const url = this.URL_SERVICIOS + '/shopify/orders/' + vendor;
-    const options = { headers: this.getHeaders() };
+    let params = new HttpParams();
+    if (created_at_min) {
+      params = params.set('created_at_min', created_at_min);
+    }
+    if (created_at_max) {
+      params = params.set('created_at_max', created_at_max);
+    }
+    const options = { headers: this.getHeaders(), params };
     return this.http.get(url, options);
   }
 


### PR DESCRIPTION
## Summary
- refine `created_at_min`/`created_at_max` handling in `ShopifyController`

## Testing
- `./mvnw -q test` *(fails: Permission denied / Network is unreachable)*
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b4bca23788323a2e534f2a44aeffc