### PR TITLE
Fix Shopify shipping null handling

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -32,8 +32,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
+@Slf4j
 public class ShopifyController {
 
     @Autowired
@@ -95,7 +97,13 @@ public class ShopifyController {
                 order.setSource("SHOPIFY");
                 order.setCurrency(o.get("currency").getAsString());
                 order.setSubtotal(o.get("subtotal_price").getAsDouble());
-                order.setShipping(o.get("total_shipping_price_set").getAsJsonObject().get("shop_money").getAsJsonObject().get("amount").getAsDouble());
+                double shipping = 0.0;
+                if (o.has("total_shipping_price_set") && !o.get("total_shipping_price_set").isJsonNull()) {
+                    shipping = o.getAsJsonObject("total_shipping_price_set")
+                                    .getAsJsonObject("shop_money")
+                                    .get("amount").getAsDouble();
+                }
+                order.setShipping(shipping);
                 order.setShipping_method("");
                 order.setCreated_at(new Date());
                 reg.setOrder(order);
@@ -141,6 +149,7 @@ public class ShopifyController {
             dto.setTipoCarga(0);
             return ResponseEntity.ok(gson.toJson(dto));
         } catch (Exception e) {
+            log.error(e.getMessage());
             return ResponseEntity.internalServerError().body(gson.toJson(new DBResponse(false, "Error consultando Shopify")));
         }
     }


### PR DESCRIPTION
## Summary
- avoid NullPointer when `total_shipping_price_set` is missing in Shopify order
- log exceptions in `ShopifyController` for easier troubleshooting

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b7eb892408323a3cfdcea401f40ef