### PR TITLE
Fix: Update Shopify API version to a supported stable version (2024-04)

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -65,7 +65,8 @@ public class ShopifyController {
             RestTemplate rest = new RestTemplate();
             HttpHeaders headers = new HttpHeaders();
             headers.add("X-Shopify-Access-Token", vendor.getShopifyAccessToken());
-            String url = "https://" + vendor.getShopifyStoreUrl() + "/admin/api/2025-07/orders.json";
+            // Changed API version from 2025-07 to 2024-04 (a supported stable version)
+            String url = "https://" + vendor.getShopifyStoreUrl() + "/admin/api/2024-04/orders.json";
             UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(url);
 
             if (createdAtMin != null && !createdAtMin.trim().isEmpty()) {


### PR DESCRIPTION
Hardcoded Shopify API version was set to a future, invalid version (2025-07), causing 500 Internal Server Errors when trying to fetch orders. This change updates the API version to 2024-04, which is a valid and supported stable version.

This should resolve the 500 error. Further investigation is recommended for the frontend to correct the `created_at_min` and `created_at_max` date parameters being sent with future and identical values.