### PR TITLE
Fix: Standardize date format in ShopifyController response

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -57,7 +57,11 @@ public class ShopifyController {
             @PathVariable String user,
             @RequestParam(value = "created_at_min", required = false) String createdAtMin,
             @RequestParam(value = "created_at_max", required = false) String createdAtMax) {
-        Gson gson = new Gson(); // Cambiado de GsonBuilder a Gson simple
+        Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX") // Formato ISO 8601
+            .setPrettyPrinting()
+            .disableHtmlEscaping()
+            .create();
         try {
             log.info("Iniciando obtenerOrders para usuario: {} con created_at_min: {} y created_at_max: {}", user, createdAtMin, createdAtMax);
 


### PR DESCRIPTION
Changed Gson configuration in ShopifyController to serialize dates in ISO 8601 format ("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"). This aims to resolve potential 400 Bad Request errors during deserialization in TransaccionesRestController due to mismatched date formats between Gson's default and Jackson's expected format.