### PR TITLE
Fix: Relax DTO validations to diagnose Shopify order processing

### DIFF
--- a/backend/src/main/java/com/rocket/service/entity/OrderDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/OrderDto.java
@@ -13,25 +13,25 @@ public class OrderDto {
 	private String id;
 	@BsonId
 	private ObjectId orderKey;
-	private String name;
-	@Email
+	private String name; // Validado por registroService.validacion()
+	// @Email // Puede permitir cadena vacía, @NotEmpty no. Se valida en registroService si es necesario.
 	private String email;
 	@NotEmpty(message = "vendor es un campo requerido")
-	private String vendor;
-	@NotEmpty(message = "risk_level es un campo requerido")
+	private String vendor; // Mantenemos esta, ya que 'user' se usa para esto.
+	// @NotEmpty(message = "risk_level es un campo requerido") // Shopify puede no enviarlo, mapeado a "N/A"
 	private String risk_level;
-	@NotEmpty(message = "vendor es un campo requerido")
+	// @NotEmpty(message = "source es un campo requerido") // Mapeado a "SHOPIFY"
 	private String source;
 	@NotEmpty(message = "financial_status es un campo requerido")
-	private String financial_status;
-	@NotEmpty(message = "accepts_marketing es un campo requerido")
+	private String financial_status; // Crítico para la lógica de guardado
+	// @NotEmpty(message = "accepts_marketing es un campo requerido") // Puede ser 'no' o no venir
 	private String accepts_marketing;
-	@NotEmpty(message = "accepts_marketing es un campo requerido")
+	// @NotEmpty(message = "currency es un campo requerido") // Shopify debería enviarlo
 	private String currency;
 	private double subtotal;	
-	@NotEmpty(message = "shipping es un campo requerido")
+	// @NotEmpty es incorrecto para double. Si se requiere que no sea cero, usar @Min(0) o validación lógica.
 	private double shipping;
-	@NotEmpty(message = "shipping_method es un campo requerido")
+	// @NotEmpty(message = "shipping_method es un campo requerido") // Puede ser vacío si no hay shipping lines
 	private String shipping_method;
 	@NotNull(message = "created_at Es un campo requerido")
 	private Date created_at;

--- a/backend/src/main/java/com/rocket/service/entity/Shipping_addressDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/Shipping_addressDto.java
@@ -1,30 +1,30 @@
 package com.rocket.service.entity;
 
-import javax.validation.constraints.NotEmpty;
+// import javax.validation.constraints.NotEmpty; // Comentado temporalmente
 
 public class Shipping_addressDto {
 	
-	@NotEmpty(message = "name es un campo requerido")
+	// @NotEmpty(message = "name es un campo requerido")
 	private String name;
-	@NotEmpty(message = "street es un campo requerido")
+	// @NotEmpty(message = "street es un campo requerido")
 	private String street;
-	@NotEmpty(message = "address1 es un campo requerido")
+	// @NotEmpty(message = "address1 es un campo requerido")
 	private String address1;
-	@NotEmpty(message = "address2 es un campo requerido")
+	// @NotEmpty(message = "address2 es un campo requerido")
 	private String address2;
-	@NotEmpty(message = "company es un campo requerido")
+	// @NotEmpty(message = "company es un campo requerido")
 	private String company;
-	@NotEmpty(message = "city es un campo requerido")
+	// @NotEmpty(message = "city es un campo requerido")
 	private String city;
-	@NotEmpty(message = "zip es un campo requerido")
+	// @NotEmpty(message = "zip es un campo requerido")
 	private String zip;
-	@NotEmpty(message = "province es un campo requerido")
+	// @NotEmpty(message = "province es un campo requerido")
 	private String province;
-	@NotEmpty(message = "province_name es un campo requerido")
+	// @NotEmpty(message = "province_name es un campo requerido")
 	private String province_name;
-	@NotEmpty(message = "country es un campo requerido")
+	// @NotEmpty(message = "country es un campo requerido")
 	private String country;
-	@NotEmpty(message = "phone es un campo requerido")
+	// @NotEmpty(message = "phone es un campo requerido")
 	private String phone;
 
 	


### PR DESCRIPTION
- Commented out @NotEmpty annotations in Shipping_addressDto.
- Adjusted/commented out @NotEmpty annotations in OrderDto for fields that might come empty from Shopify API (e.g., email, risk_level, shipping_method, currency, accepts_marketing).
- Removed invalid @NotEmpty annotation from double field 'shipping' in OrderDto.

Este cambio está destinado a permitir las cargas útiles con cadenas vacías para ciertos campos de dirección y pedido para aprobar la validación inicial del marco, trasladando la responsabilidad de validación a la lógica comercial en registros de registros. El objetivo es obtener mensajes de error detallados en la respuesta LoadDTO en lugar de una solicitud genérica de 400 malas, para determinar aún más la asignación o los problemas de datos de Shopify.