### PR TITLE
Feat: Add debug field to ShopifyController response and update fronte…

### DIFF
--- a/frontend/src/app/pages/carga-layout/carga-layout.component.ts
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.ts
@@ -99,19 +99,30 @@ export class CargaLayoutComponent implements OnInit {
     }
 
     this.shopifyService.obtenerOrders(vendor, inicioISO, finISO).subscribe(
-      (data: any) => {
-        console.log('Respuesta de shopifyService.obtenerOrders:', JSON.stringify(data));
+      (response: any) => { // 'response' ahora es el Map que contiene 'payload' y 'debugShopifyResponse'
+        console.log('Respuesta completa de shopifyService.obtenerOrders:', JSON.stringify(response));
 
-        if (data && data.registro) {
-          if (data.registro.length > 0) {
-            this.toastrService.info(`Se encontraron ${data.registro.length} pedidos de Shopify. Enviando para registro...`, 'Información', { duration: 5000 });
+        if (response && response.debugShopifyResponse) {
+          console.log('Datos de depuración de Shopify (respuesta cruda del primer pedido o mensaje de error):', response.debugShopifyResponse);
+        }
+
+        // Mover al paso de previsualización/resultados aquí, después de recibir la respuesta.
+        if (this.stepper) {
+            this.stepper.selectedIndex = 1;
+        }
+
+        const payloadData = response && response.payload ? response.payload : null; // Extraer el payload original
+
+        if (payloadData && payloadData.registro) {
+          if (payloadData.registro.length > 0) {
+            this.toastrService.info(`Se encontraron ${payloadData.registro.length} pedidos de Shopify. Enviando para registro...`, 'Información', { duration: 5000 });
           } else {
-            this.toastrService.warning('No se encontraron pedidos de Shopify para las fechas seleccionadas.', 'Información', { duration: 5000 });
+            this.toastrService.warning('No se encontraron pedidos de Shopify para las fechas seleccionadas o la respuesta de Shopify estaba vacía.', 'Información', { duration: 5000 });
           }
-          // Continuamos pasando los datos (incluso si están vacíos) a previsualizacion.registerTest
-          // para mantener el flujo actual y que el backend genere la respuesta de 0 registros si es el caso.
+
           if (this.previsualizacion) {
-            this.previsualizacion.registerTest(JSON.stringify(data));
+            // Enviar solo el payload (que es el RegistroServiceInDto) al método registerTest
+            this.previsualizacion.registerTest(JSON.stringify(payloadData));
           } else {
              this.toastrService.danger('Error: Componente de previsualización no encontrado.', 'Error Fatal', { duration: 5000 });
              this.resultado = { registrosExitosos: 0, registrosFallidos: 0, registrosOmitidos: 0, respuesta: 'Error: Componente de previsualización no encontrado.' };
@@ -119,9 +130,11 @@ export class CargaLayoutComponent implements OnInit {
              if (this.stepper) { this.stepper.selectedIndex = 2; }
           }
         } else {
-          console.error('La respuesta de obtenerOrders no tiene la estructura esperada:', data);
-          this.toastrService.danger('Error al procesar la respuesta de Shopify. Estructura inesperada.', 'Error', { duration: 5000 });
-          this.resultado = { registrosExitosos: 0, registrosFallidos: 0, registrosOmitidos: 0, respuesta: 'Error: Respuesta inesperada del servidor al obtener pedidos.' };
+          // Esto podría ocurrir si response.payload es null o response.payload.registro es undefined
+          // o si la propia 'response' es null/undefined (ej. error HTTP no capturado por el .catch del servicio)
+          console.error('La respuesta de obtenerOrders no tiene la estructura esperada (payload o payload.registro es nulo/undefined):', response);
+          this.toastrService.danger('Error al procesar la respuesta de Shopify: estructura de payload inesperada.', 'Error', { duration: 5000 });
+          this.resultado = { registrosExitosos: 0, registrosFallidos: 0, registrosOmitidos: 0, respuesta: 'Error: Respuesta de servidor (Shopify) con formato inesperado o sin datos de pedidos.' };
           this.errores = [];
           if (this.stepper) {
             this.stepper.selectedIndex = 2;


### PR DESCRIPTION
…nd handling

- ShopifyController.java:
  - Modified obtenerOrders to return a Map containing the original payload and a new 'debugShopifyResponse' field.
  - The 'debugShopifyResponse' field includes a string representation of the first raw order object received from Shopify or an error/empty message.
  - This is to help debug the structure of the data received from Shopify API.

- CargaLayoutComponent.ts:
  - Updated to handle the new Map response structure from shopifyService.obtenerOrders.
  - Logs the 'debugShopifyResponse' to the browser console.
  - Passes the original 'payload' (RegistroServiceInDto) to the previsualizacion component.

This change is intended to provide visibility into the raw Shopify order data as received by the backend, to diagnose discrepancies in address field mapping.