### PR TITLE
Fix: Request detailed fields from Shopify API and revert debug respon…

### DIFF
--- a/frontend/src/app/pages/carga-layout/carga-layout.component.ts
+++ b/frontend/src/app/pages/carga-layout/carga-layout.component.ts
@@ -99,30 +99,23 @@ export class CargaLayoutComponent implements OnInit {
     }
 
     this.shopifyService.obtenerOrders(vendor, inicioISO, finISO).subscribe(
-      (response: any) => { // 'response' ahora es el Map que contiene 'payload' y 'debugShopifyResponse'
-        console.log('Respuesta completa de shopifyService.obtenerOrders:', JSON.stringify(response));
-
-        if (response && response.debugShopifyResponse) {
-          console.log('Datos de depuración de Shopify (respuesta cruda del primer pedido o mensaje de error):', response.debugShopifyResponse);
-        }
+      (data: any) => { // 'data' ahora es directamente el RegistroServiceInDto
+        console.log('Respuesta de shopifyService.obtenerOrders (debería ser RegistroServiceInDto):', JSON.stringify(data));
 
         // Mover al paso de previsualización/resultados aquí, después de recibir la respuesta.
         if (this.stepper) {
             this.stepper.selectedIndex = 1;
         }
 
-        const payloadData = response && response.payload ? response.payload : null; // Extraer el payload original
-
-        if (payloadData && payloadData.registro) {
-          if (payloadData.registro.length > 0) {
-            this.toastrService.info(`Se encontraron ${payloadData.registro.length} pedidos de Shopify. Enviando para registro...`, 'Información', { duration: 5000 });
+        if (data && data.registro) { // data es directamente el payload esperado
+          if (data.registro.length > 0) {
+            this.toastrService.info(`Se encontraron ${data.registro.length} pedidos de Shopify. Enviando para registro...`, 'Información', { duration: 5000 });
           } else {
             this.toastrService.warning('No se encontraron pedidos de Shopify para las fechas seleccionadas o la respuesta de Shopify estaba vacía.', 'Información', { duration: 5000 });
           }
 
           if (this.previsualizacion) {
-            // Enviar solo el payload (que es el RegistroServiceInDto) al método registerTest
-            this.previsualizacion.registerTest(JSON.stringify(payloadData));
+            this.previsualizacion.registerTest(JSON.stringify(data)); // Enviar el 'data' directamente
           } else {
              this.toastrService.danger('Error: Componente de previsualización no encontrado.', 'Error Fatal', { duration: 5000 });
              this.resultado = { registrosExitosos: 0, registrosFallidos: 0, registrosOmitidos: 0, respuesta: 'Error: Componente de previsualización no encontrado.' };
@@ -130,10 +123,8 @@ export class CargaLayoutComponent implements OnInit {
              if (this.stepper) { this.stepper.selectedIndex = 2; }
           }
         } else {
-          // Esto podría ocurrir si response.payload es null o response.payload.registro es undefined
-          // o si la propia 'response' es null/undefined (ej. error HTTP no capturado por el .catch del servicio)
-          console.error('La respuesta de obtenerOrders no tiene la estructura esperada (payload o payload.registro es nulo/undefined):', response);
-          this.toastrService.danger('Error al procesar la respuesta de Shopify: estructura de payload inesperada.', 'Error', { duration: 5000 });
+          console.error('La respuesta de obtenerOrders no tiene la estructura esperada (data o data.registro es nulo/undefined):', data);
+          this.toastrService.danger('Error al procesar la respuesta de Shopify: estructura inesperada.', 'Error', { duration: 5000 });
           this.resultado = { registrosExitosos: 0, registrosFallidos: 0, registrosOmitidos: 0, respuesta: 'Error: Respuesta de servidor (Shopify) con formato inesperado o sin datos de pedidos.' };
           this.errores = [];
           if (this.stepper) {


### PR DESCRIPTION
…se structure

- ShopifyController.java:
  - Added explicit 'fields' parameter to the Shopify API call to request all necessary order data, including full shipping and billing address details.
  - Reverted the response structure to directly return the serialized RegistroServiceInDto, removing the temporary debug map.
  - Kept detailed logging for the raw Shopify API response within the controller.

- CargaLayoutComponent.ts:
  - Updated to expect RegistroServiceInDto directly from shopifyService.obtenerOrders again.

This aims to ensure all required address fields are fetched from Shopify, allowing business validations in TransaccionesRestController to pass and orders to be saved correctly.