### PR TITLE
Debug: Force critical ShopifyController logs to ERROR level

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
+++ b/backend/src/main/java/com/rocket/service/controller/ShopifyController.java
@@ -151,8 +151,7 @@ public class ShopifyController {
             }
 
             log.info("Shopify API Response Status: {}", resp.getStatusCode());
-            // No loguear todo el body si puede ser muy grande, solo si es necesario para debug puntual.
-            // log.info("Shopify API Response Body: {}", resp.getBody());
+            log.error("DEBUG - Shopify API Response Body: {}", resp.getBody()); // Cambiado a log.error para depuración
 
             JsonObject obj = JsonParser.parseString(resp.getBody()).getAsJsonObject();
             JsonArray ordersArray = obj.getAsJsonArray("orders");


### PR DESCRIPTION
Changed key logging statements in ShopifyController.java related to Shopify API response and address mapping from INFO/DEBUG to ERROR level (prefixed with "DEBUG - ").
This is a temporary measure to ensure these logs are visible in CloudWatch to diagnose the address field mapping issue.