### PR TITLE
Add Shopify plan notice and missing store warning

### DIFF
--- a/frontend/src/app/pages/configuracion/configuracion.component.html
+++ b/frontend/src/app/pages/configuracion/configuracion.component.html
@@ -1,6 +1,9 @@
 <nb-card>
   <nb-card-header>Configuración Shopify</nb-card-header>
   <nb-card-body>
+    <p class="text-muted" style="margin-bottom: 1rem;">
+      Si cuentas con el plan básico de Shopify, tu token no funcionará. Se requiere al menos la membresía <b>Grow</b>.
+    </p>
     <form (ngSubmit)="guardar()">
       <div class="form-group">
         <label for="accessToken" class="label">Access Token</label>

--- a/frontend/src/app/pages/configuracion/configuracion.component.ts
+++ b/frontend/src/app/pages/configuracion/configuracion.component.ts
@@ -46,6 +46,11 @@ export class ConfiguracionComponent implements OnInit {
                     );
                   }
                 );
+            } else {
+              this.toastrService.warning(
+                'Aún no tienes una tienda asociada. Contacta a tu administrador.',
+                'Sin tienda'
+              );
             }
           },
           (err) => {
@@ -60,6 +65,10 @@ export class ConfiguracionComponent implements OnInit {
   guardar() {
     if (!this.vendorId) {
       console.error('Vendor ID no disponible');
+      this.toastrService.warning(
+        'No es posible guardar porque no tienes una tienda asociada.',
+        'Sin tienda'
+      );
       return;
     }
     this.saving = true;


### PR DESCRIPTION
## Summary
- notify vendors if they don't have a store associated
- show a warning message about Shopify plan requirements in configuration page

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd3f24808832396b8c0bdd57570e6