### PR TITLE
Add Shopify plan notice and missing store warning

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/RegistroController.java
+++ b/backend/src/main/java/com/rocket/service/controller/RegistroController.java
@@ -20,6 +20,7 @@ import com.rocket.service.service.EstatusService;
 import com.rocket.service.service.RegistroService;
 import com.rocket.service.service.RolService;
 import com.rocket.service.service.UsuarioService;
+import org.bson.types.ObjectId;
 import com.rocket.service.service.VendorService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -153,5 +154,23 @@ public class RegistroController {
 
         json = gson.toJson(groupingEstatusRegistroServiceOutDto);
         return new ResponseEntity<>(json, HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/registro/{orderKey}", method = RequestMethod.DELETE, produces = {
+            "application/json;charset=UTF-8" })
+    public ResponseEntity<String> eliminarRegistro(@PathVariable String orderKey) {
+        Gson gson = new Gson();
+        DBResponse response;
+        try {
+            boolean eliminado = registroService.eliminarRegistro(new ObjectId(orderKey));
+            if (eliminado) {
+                response = new DBResponse(true, "Registro eliminado");
+            } else {
+                response = new DBResponse(false, "Registro no encontrado");
+            }
+        } catch (Exception e) {
+            response = new DBResponse(false, "Error al eliminar el registro");
+        }
+        return new ResponseEntity<>(gson.toJson(response), HttpStatus.OK);
     }
 }

--- a/backend/src/main/java/com/rocket/service/service/RegistroService.java
+++ b/backend/src/main/java/com/rocket/service/service/RegistroService.java
@@ -55,9 +55,18 @@ public class RegistroService {
 		return repoRegis.findAll();
 	}
 
-	public RegistryDto buscarPorOrderKey(ObjectId orderKey) {
-		return repoRegis.findByOrderKey(orderKey);
-	}
+        public RegistryDto buscarPorOrderKey(ObjectId orderKey) {
+                return repoRegis.findByOrderKey(orderKey);
+        }
+
+        public boolean eliminarRegistro(ObjectId orderKey) {
+                RegistryDto registro = repoRegis.findByOrderKey(orderKey);
+                if (registro != null) {
+                        repoRegis.delete(registro);
+                        return true;
+                }
+                return false;
+        }
 
 	public List<RegistryDto> consultaRegistroCargaEstatus(Long idCarga, Integer idEstatus, String courier) {
 		List<RegistryDto> registros = new ArrayList<>();

--- a/frontend/src/app/pages/configuracion/configuracion.component.html
+++ b/frontend/src/app/pages/configuracion/configuracion.component.html
@@ -1,6 +1,9 @@
 <nb-card>
   <nb-card-header>Configuración Shopify</nb-card-header>
   <nb-card-body>
+    <p class="text-muted" style="margin-bottom: 1rem;">
+      Si cuentas con el plan básico de Shopify, tu token no funcionará. Se requiere al menos la membresía <b>Grow</b>.
+    </p>
     <form (ngSubmit)="guardar()">
       <div class="form-group">
         <label for="accessToken" class="label">Access Token</label>

--- a/frontend/src/app/pages/configuracion/configuracion.component.ts
+++ b/frontend/src/app/pages/configuracion/configuracion.component.ts
@@ -46,6 +46,11 @@ export class ConfiguracionComponent implements OnInit {
                     );
                   }
                 );
+            } else {
+              this.toastrService.warning(
+                'Aún no tienes una tienda asociada. Contacta a tu administrador.',
+                'Sin tienda'
+              );
             }
           },
           (err) => {
@@ -60,6 +65,10 @@ export class ConfiguracionComponent implements OnInit {
   guardar() {
     if (!this.vendorId) {
       console.error('Vendor ID no disponible');
+      this.toastrService.warning(
+        'No es posible guardar porque no tienes una tienda asociada.',
+        'Sin tienda'
+      );
       return;
     }
     this.saving = true;

--- a/frontend/src/app/pages/consulta-informacion/resultado-consulta/resultado-consulta.component.html
+++ b/frontend/src/app/pages/consulta-informacion/resultado-consulta/resultado-consulta.component.html
@@ -47,6 +47,12 @@
         Limpiar agenda
       </button>
     </div>
+    <div class="p-2">
+      <button mat-raised-button color="warn" matRipple [disabled]="selection.selected.length == 0" (click)="eliminarPedidos()">
+        <nb-icon icon="trash-2-outline"></nb-icon>
+        Eliminar
+      </button>
+    </div>
   </div>
 
   <div class="d-flex justify-content-lg-end flex-wrap" *ngIf="canRenderAdmin()">

--- a/frontend/src/app/pages/consulta-informacion/resultado-consulta/resultado-consulta.component.ts
+++ b/frontend/src/app/pages/consulta-informacion/resultado-consulta/resultado-consulta.component.ts
@@ -31,6 +31,7 @@ import { EstatusService } from 'src/app/services/estatus.service';
 import { CambioEstatusMultipleComponent } from '../popups/cambio-estatus-multiple/cambio-estatus-multiple.component';
 import { GlobalAcceptanceComponent } from '../../common-popups/global-acceptance/global-acceptance.component';
 import { TipoEstatus } from '../../../models/tipo.estatus.model';
+import { forkJoin } from 'rxjs';
 
 @Component({
   selector: 'app-resultado-consulta',
@@ -818,6 +819,56 @@ export class ResultadoConsultaComponent
                 );
               }
             );
+        } else {
+          this.selection.clear();
+        }
+      });
+  }
+
+  eliminarPedidos() {
+    this.dialogService
+      .open(GlobalAcceptanceComponent, {
+        closeOnBackdropClick: false,
+        closeOnEsc: true,
+        context: {
+          headerMessage: 'Eliminación de pedidos',
+          bodyMessage:
+            '¿Desea eliminar [' +
+            this.selection.selected.length +
+            '] pedido(s)?',
+          acceptanceLabel: 'Si',
+          cancelLabel: 'No',
+        },
+      })
+      .onClose.subscribe((response) => {
+        if (response.accept == true) {
+          const deletes = this.selection.selected.map((register) =>
+            this.registroService.eliminarRegistro(register.orderkey)
+          );
+          this.loading.emit(true);
+          forkJoin(deletes).subscribe(
+            () => {
+              this.selection.selected.forEach((registro) => {
+                this.registros = this.arrayRemove(this.registros, registro);
+              });
+              this.selection.clear();
+              this.dataSource = new MatTableDataSource(this.registros);
+              this.dataSource.paginator = this.paginator;
+              this.loading.emit(false);
+              this.toastrService.success(
+                'Se eliminaron correctamente los pedidos',
+                'Eliminación'
+              );
+            },
+            (error) => {
+              console.error(error);
+              this.loading.emit(false);
+              this.toastrService.danger(
+                'Ocurrió un error al eliminar los pedidos',
+                'Eliminación'
+              );
+            }
+          );
         } else {
           this.selection.clear();
         }

--- a/frontend/src/app/services/registro.service.ts
+++ b/frontend/src/app/services/registro.service.ts
@@ -198,6 +198,12 @@ export class RegistroService {
     });
   }
 
+  eliminarRegistro(orderKey: string) {
+    const url = this.URL_SERVICIOS + '/registro/' + orderKey;
+    const options = { headers: this.getHeaders() };
+    return this.http.delete(url, options);
+  }
+
   private getHeaders() {
     let headers = new HttpHeaders({
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- notify vendors if they don't have a store associated
- show a warning message about Shopify plan requirements in configuration page
- allow vendors to delete orders from Consulta Registros

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable during Maven wrapper download)*
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd3f24808832396b8c0bdd57570e6