### PR TITLE
Add Shopify load page

### DIFF
--- a/frontend/src/app/pages/carga-shopify/carga-shopify.component.html
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.component.html
@@ -1,0 +1,18 @@
+<nb-card>
+  <nb-card-body style="padding: 50px;">
+    <div class="row mb-3">
+      <div class="col">
+        <label for="fechaInicioInput" class="label">Fecha de Inicio</label>
+        <input id="fechaInicioInput" nbInput type="date" placeholder="Fecha inicio" [(ngModel)]="fechaInicio" />
+      </div>
+      <div class="col">
+        <label for="fechaFinInput" class="label">Fecha de Fin</label>
+        <input id="fechaFinInput" nbInput type="date" placeholder="Fecha fin" [(ngModel)]="fechaFin" />
+      </div>
+    </div>
+    <button nbButton status="primary" (click)="cargarMisEnvios()" class="mb-4">
+      Cargar mis envíos
+    </button>
+    <app-shopify-result [resultado]="resultado" [errores]="errores"></app-shopify-result>
+  </nb-card-body>
+</nb-card>

--- a/frontend/src/app/pages/carga-shopify/carga-shopify.component.scss
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.component.scss
@@ -1,0 +1,3 @@
+@import '../../../themes';
+
+@include nb-install-component {}

--- a/frontend/src/app/pages/carga-shopify/carga-shopify.component.ts
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.component.ts
@@ -1,0 +1,169 @@
+import { Component, OnInit } from '@angular/core';
+import { NbAuthOAuth2JWTToken, NbAuthService } from '@nebular/auth';
+import { NbToastrService } from '@nebular/theme';
+import { ShopifyService } from '../../services/shopify.service';
+import { RegistroService } from '../../services/registro.service';
+
+@Component({
+  selector: 'app-carga-shopify',
+  templateUrl: './carga-shopify.component.html',
+  styleUrls: ['./carga-shopify.component.scss']
+})
+export class CargaShopifyComponent implements OnInit {
+  user: any;
+  fechaInicio: string;
+  fechaFin: string;
+  resultado: any;
+  errores: any[] = [];
+  procesado = false;
+
+  constructor(
+    private shopifyService: ShopifyService,
+    private authService: NbAuthService,
+    private registroService: RegistroService,
+    private toastrService: NbToastrService
+  ) {}
+
+  ngOnInit(): void {
+    this.authService.onTokenChange().subscribe((token: NbAuthOAuth2JWTToken) => {
+      if (token.isValid()) {
+        this.user = token.getAccessTokenPayload();
+      }
+    });
+
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = ('0' + (today.getMonth() + 1)).slice(-2);
+    const day = ('0' + today.getDate()).slice(-2);
+    this.fechaInicio = `${year}-${month}-${day}`;
+    this.fechaFin = `${year}-${month}-${day}`;
+  }
+
+  private setResultado(res: any) {
+    this.resultado = res;
+    if (res && res.respuesta) {
+      if (
+        res.registrosFallidos > 0 ||
+        (res.registrosOmitidos > 0 && res.registrosExitosos === 0 && res.registrosFallidos === 0)
+      ) {
+        this.errores = typeof res.respuesta === 'string' ? res.respuesta.split('|').map((e: string) => e.trim()) : [];
+      } else {
+        this.errores = [];
+      }
+    } else {
+      this.errores = [];
+    }
+  }
+
+  cargarMisEnvios() {
+    if (!this.user) {
+      this.toastrService.show('No se pudo obtener la información del usuario.', 'Error', { status: 'danger', duration: 5000 });
+      return;
+    }
+    if (!this.fechaInicio || !this.fechaFin) {
+      this.toastrService.show('Por favor, seleccione fecha de inicio y fin.', 'Advertencia', { status: 'warning', duration: 5000 });
+      return;
+    }
+
+    const vendor = this.user.user_name || this.user.name || this.user.sub;
+    if (!vendor) {
+      this.toastrService.show('No se pudo determinar el vendor.', 'Error', { status: 'danger', duration: 5000 });
+      return;
+    }
+
+    const startDate = new Date(this.fechaInicio);
+    startDate.setUTCHours(0, 0, 0, 0);
+    const inicioISO = startDate.toISOString();
+
+    const endDate = new Date(this.fechaFin);
+    endDate.setUTCHours(23, 59, 59, 999);
+    const finISO = endDate.toISOString();
+
+    this.toastrService.info('Obteniendo pedidos de Shopify...', 'Procesando', { duration: 3000 });
+    this.procesado = true;
+    this.resultado = null;
+    this.errores = [];
+
+    this.shopifyService.obtenerOrders(vendor, inicioISO, finISO).subscribe(
+      (payloadShopify: any) => {
+        if (payloadShopify && typeof payloadShopify.registro !== 'undefined') {
+          if (payloadShopify.registro.length > 0) {
+            this.toastrService.info(`Se encontraron ${payloadShopify.registro.length} pedidos de Shopify. Registrando en la base de datos...`, 'Procesando', { duration: 3000 });
+            this.registroService.registrarCarga(payloadShopify).subscribe(
+              (resultadoCarga: any) => {
+                this.setResultado(resultadoCarga);
+                const toastMessage = `Carga API: ${resultadoCarga.registrosExitosos || 0} exitosos, ${resultadoCarga.registrosFallidos || 0} fallidos, ${resultadoCarga.registrosOmitidos || 0} omitidos.`;
+                if (resultadoCarga.registrosFallidos > 0 || (resultadoCarga.registrosOmitidos > 0 && resultadoCarga.registrosExitosos === 0 && resultadoCarga.registrosFallidos === 0)) {
+                  this.toastrService.warning(toastMessage, 'Resultado de Carga', { duration: 8000 });
+                } else {
+                  this.toastrService.success(toastMessage, 'Resultado de Carga', { duration: 5000 });
+                }
+                this.procesado = false;
+              },
+              (errorRegistro: any) => {
+                const detailError = errorRegistro.error?.respuesta || errorRegistro.error?.error || errorRegistro.error?.message || errorRegistro.message || 'Error desconocido al registrar.';
+                this.toastrService.danger(`Error al registrar los pedidos: ${detailError}`, 'Error Fatal', { duration: 8000 });
+                this.resultado = {
+                  idCarga: null,
+                  uploadDate: new Date().toISOString(),
+                  registrosExitosos: 0,
+                  registrosFallidos: payloadShopify.registro ? payloadShopify.registro.length : 0,
+                  registrosOmitidos: 0,
+                  respuesta: `Error al registrar pedidos: ${detailError}`,
+                  idVendor: vendor,
+                  tipoCarga: 0
+                };
+                this.setResultado(this.resultado);
+                this.procesado = false;
+              }
+            );
+          } else {
+            this.toastrService.warning('No se encontraron pedidos de Shopify para las fechas seleccionadas.', 'Información', { duration: 5000 });
+            this.resultado = {
+              idCarga: null,
+              uploadDate: new Date().toISOString(),
+              registrosExitosos: 0,
+              registrosFallidos: 0,
+              registrosOmitidos: 0,
+              respuesta: 'No se encontraron pedidos de Shopify para procesar.',
+              idVendor: vendor,
+              tipoCarga: 0
+            };
+            this.setResultado(this.resultado);
+            this.procesado = false;
+          }
+        } else {
+          this.toastrService.danger('Error al procesar la respuesta de Shopify: estructura inesperada.', 'Error', { duration: 5000 });
+          this.resultado = {
+            idCarga: null,
+            uploadDate: new Date().toISOString(),
+            registrosExitosos: 0,
+            registrosFallidos: 0,
+            registrosOmitidos: 0,
+            respuesta: 'Error: Respuesta inesperada del servidor al obtener pedidos.',
+            idVendor: vendor,
+            tipoCarga: 0
+          };
+          this.setResultado(this.resultado);
+          this.procesado = false;
+        }
+      },
+      (errorObtenerOrders: any) => {
+        const errorMessage = errorObtenerOrders.error?.responseMessage || errorObtenerOrders.error?.error || errorObtenerOrders.error?.message || 'Error desconocido al conectar con Shopify.';
+        this.toastrService.danger(`Error al conectar con Shopify: ${errorMessage}`, 'Error', { duration: 8000 });
+        this.resultado = {
+          idCarga: null,
+          uploadDate: new Date().toISOString(),
+          registrosExitosos: 0,
+          registrosFallidos: 0,
+          registrosOmitidos: 0,
+          respuesta: `Error al conectar con Shopify: ${errorMessage}`,
+          idVendor: vendor,
+          tipoCarga: 0
+        };
+        this.setResultado(this.resultado);
+        this.procesado = false;
+      }
+    );
+  }
+}

--- a/frontend/src/app/pages/carga-shopify/carga-shopify.module.ts
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CargaShopifyComponent } from './carga-shopify.component';
+import { ThemeModule } from '../../theme/theme.module';
+import { MaterialModule } from '../../material/material.module';
+import { ShopifyResultComponent } from './shopify-result/shopify-result.component';
+
+@NgModule({
+  declarations: [CargaShopifyComponent, ShopifyResultComponent],
+  imports: [CommonModule, ThemeModule, MaterialModule]
+})
+export class CargaShopifyModule {}

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
@@ -1,0 +1,40 @@
+<h2>Resultados de la carga</h2>
+<nb-alert outline="success" *ngIf="resultado">
+  <table class="table">
+    <thead class="thead-dark">
+      <tr>
+        <th scope="col">Concepto</th>
+        <th scope="col">Valor</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Registros almacenados en base</td>
+        <td>{{resultado.registrosExitosos}}</td>
+      </tr>
+      <tr>
+        <td>Registros con error</td>
+        <td>{{resultado.registrosFallidos}}</td>
+      </tr>
+      <tr>
+        <td>Registros omitidos</td>
+        <td>{{resultado.registrosOmitidos + errores.length}}</td>
+      </tr>
+    </tbody>
+  </table>
+</nb-alert>
+
+<nb-alert outline="danger" *ngIf="errores && false">
+  <span *ngFor="let error of errores">
+    <b>Error en la fila [{{error.rowNumber}}] </b>:
+    Los siguientes campos son requeridos:
+    <ul>
+      <li *ngFor="let column of error.errors">{{column}}</li>
+    </ul>
+  </span>
+</nb-alert>
+
+<button mat-raised-button color="primary" (click)="finaliza()" type="button" [ngStyle]="{'float':'right'}">
+  <nb-icon icon="arrow-circle-right-outline"></nb-icon>
+  Finalizar
+</button>

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.scss
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.scss
@@ -1,0 +1,19 @@
+:host ::ng-deep {    
+    .p-datatable table {
+        table-layout: inherit !important;
+        white-space: nowrap
+    }
+}
+
+:host ::ng-deep .header {
+    background-color: #ff7010 !important;
+    color: rgb(255, 255, 255) !important;
+    font-weight: bold;
+}
+
+.centered {
+   // position: fixed;
+    margin: auto;
+    /* bring your own prefixes */
+    //transform: translate(-50%, -50%);
+  }

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input, OnChanges } from '@angular/core';
+
+@Component({
+  selector: 'app-shopify-result',
+  templateUrl: './shopify-result.component.html',
+  styleUrls: ['./shopify-result.component.scss']
+})
+export class ShopifyResultComponent implements OnChanges {
+  @Input() resultado: any;
+  @Input() errores: any[];
+
+  ngOnChanges(): void {}
+}

--- a/frontend/src/app/pages/pages-menu.ts
+++ b/frontend/src/app/pages/pages-menu.ts
@@ -29,6 +29,15 @@ export const admin_menu: NbMenuItem[] = [
     },
   },
   {
+    title: 'Carga Shopify',
+    icon: 'shopping-bag-outline',
+    link: '/intranet/carga-shopify',
+    data: {
+      permission: 'menu',
+      resource: ['customer']
+    },
+  },
+  {
     title: 'Consulta de información',
     icon: 'file-text-outline',
     link: '/intranet/consulta-registros',

--- a/frontend/src/app/pages/pages-routing.module.ts
+++ b/frontend/src/app/pages/pages-routing.module.ts
@@ -4,6 +4,7 @@ import { PagesComponent } from './pages.component';
 import { HomeComponent } from './home/home.component';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { CargaLayoutComponent } from './carga-layout/carga-layout.component';
+import { CargaShopifyComponent } from './carga-shopify/carga-shopify.component';
 import { AuthGuard } from '../auth.guard';
 import { ConsultaInformacionComponent } from './consulta-informacion/consulta-informacion.component';
 import { GestionUsuariosComponent } from './gestion-usuarios/gestion-usuarios.component';
@@ -24,6 +25,14 @@ const routes: Routes = [{
       component: CargaLayoutComponent,
       data: {
         resource: ['messenger', 'customer'],
+      },
+      canActivate: [AuthGuard],
+    },
+    {
+      path: 'carga-shopify',
+      component: CargaShopifyComponent,
+      data: {
+        resource: ['customer'],
       },
       canActivate: [AuthGuard],
     },

--- a/frontend/src/app/pages/pages.module.ts
+++ b/frontend/src/app/pages/pages.module.ts
@@ -17,6 +17,7 @@ import {
 import { NbEvaIconsModule } from '@nebular/eva-icons';
 import { ThemeModule } from '../theme/theme.module';
 import { CargaLayoutModule } from './carga-layout/carga-layout.module';
+import { CargaShopifyModule } from './carga-shopify/carga-shopify.module';
 import { NgxLoadingXModule } from 'ngx-loading-x';
 import { ConsultaInformacionModule } from './consulta-informacion/consulta-informacion.module';
 import { NgxSpinnerModule } from 'ngx-spinner';
@@ -32,6 +33,7 @@ import { GlobalAcceptanceComponent } from './common-popups/global-acceptance/glo
     PagesRoutingModule,
     HomeModule,
     CargaLayoutModule,
+    CargaShopifyModule,
     NotFoundModule,
     NbLayoutModule,
     NbSidebarModule,


### PR DESCRIPTION
## Summary
- add `CargaShopifyComponent` and module
- display Shopify results
- route `/carga-shopify` guarded for customers only
- add menu entry for Shopify load

## Testing
- `npx ng lint` *(fails: could not determine executable)*
- `npx ng test --watch=false` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_686dfc0b859c8323bbc28247550ce370