### PR TITLE
Fix: Add missing finaliza method to ShopifyResultComponent

### DIFF
--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
@@ -10,4 +10,9 @@ export class ShopifyResultComponent implements OnChanges {
   @Input() errores: any[];
 
   ngOnChanges(): void {}
+
+  finaliza(): void {
+    // TODO: Implement actual finalization logic
+    console.log('finaliza() called');
+  }
 }


### PR DESCRIPTION
This commit resolves a build error caused by the missing 'finaliza' method in the ShopifyResultComponent. The method has been added with a placeholder console.log statement. Further implementation of the finalization logic may be required.