### PR TITLE
Update Shopify load page UI

### DIFF
--- a/frontend/src/app/pages/carga-shopify/carga-shopify.component.html
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.component.html
@@ -1,5 +1,6 @@
 <nb-card>
   <nb-card-body style="padding: 50px;">
+    <h2 class="mb-4">Carga de Pedidos Shopify</h2>
     <div class="row mb-3">
       <div class="col">
         <label for="fechaInicioInput" class="label">Fecha de Inicio</label>
@@ -10,7 +11,7 @@
         <input id="fechaFinInput" nbInput type="date" placeholder="Fecha fin" [(ngModel)]="fechaFin" />
       </div>
     </div>
-    <button nbButton status="primary" (click)="cargarMisEnvios()" class="mb-4">
+    <button nbButton status="primary" (click)="cargarMisEnvios()" class="mb-4 load-button">
       Cargar mis envíos
     </button>
     <app-shopify-result [resultado]="resultado" [errores]="errores"></app-shopify-result>

--- a/frontend/src/app/pages/carga-shopify/carga-shopify.component.scss
+++ b/frontend/src/app/pages/carga-shopify/carga-shopify.component.scss
@@ -1,3 +1,9 @@
 @import '../../../themes';
 
 @include nb-install-component {}
+
+.load-button {
+  background-color: #98C14D !important;
+  border-color: #98C14D !important;
+  color: #fff !important;
+}

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
@@ -33,8 +33,3 @@
     </ul>
   </span>
 </nb-alert>
-
-<button mat-raised-button color="primary" (click)="finaliza()" type="button" [ngStyle]="{'float':'right'}">
-  <nb-icon icon="arrow-circle-right-outline"></nb-icon>
-  Finalizar
-</button>

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.ts
@@ -10,9 +10,4 @@ export class ShopifyResultComponent implements OnChanges {
   @Input() errores: any[];
 
   ngOnChanges(): void {}
-
-  finaliza(): void {
-    // TODO: Implement actual finalization logic
-    console.log('finaliza() called');
-  }
 }


### PR DESCRIPTION
## Summary
- add page title to Shopify load page
- make the 'Cargar mis envíos' button match Shopify green
- remove unused finalization button

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_686e0a3e656c8323a4530a584614036c