### PR TITLE
Fix duplicated omit count display

### DIFF
--- a/frontend/src/app/pages/carga-layout/show-result/show-result.component.html
+++ b/frontend/src/app/pages/carga-layout/show-result/show-result.component.html
@@ -18,7 +18,7 @@
       </tr>
       <tr>
         <td>Registros omitidos</td>
-        <td>{{resultado.registrosOmitidos + errores.length}}</td>
+        <td>{{resultado.registrosOmitidos}}</td>
       </tr>
     </tbody>
   </table>
@@ -36,5 +36,4 @@
 
 <button mat-raised-button color="primary" (click)="finaliza()" type="button" [ngStyle]="{'float':'right'}">
   <nb-icon icon="arrow-circle-right-outline"></nb-icon>
-  Finalizar
-</button>
+  Finalizar</button>

--- a/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
+++ b/frontend/src/app/pages/carga-shopify/shopify-result/shopify-result.component.html
@@ -19,7 +19,7 @@
       </tr>
       <tr>
         <td>Registros omitidos</td>
-        <td>{{resultado.registrosOmitidos + errores.length}}</td>
+        <td>{{resultado.registrosOmitidos}}</td>
       </tr>
     </tbody>
   </table>
@@ -32,5 +32,4 @@
     <ul>
       <li *ngFor="let column of error.errors">{{column}}</li>
     </ul>
-  </span>
-</nb-alert>
+  </span></nb-alert>


### PR DESCRIPTION
## Summary
- fix duplicated `Registros omitidos` count by removing extra addition in `app-shopify-result` component
- fix same issue in `show-result` component

## Testing
- `npm test -- -w false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1d1dfabc83239146582f44318087