### PR TITLE
Integrate Shopify fulfillment retrieval on agenda acceptance

### DIFF
--- a/backend/src/main/java/com/rocket/service/entity/OrderDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/OrderDto.java
@@ -34,7 +34,12 @@ public class OrderDto {
 	// @NotEmpty es incorrecto para double. Si se requiere que no sea cero, usar @Min(0) o validación lógica.
 	private double shipping;
 	// @NotEmpty(message = "shipping_method es un campo requerido") // Puede ser vacío si no hay shipping lines
-	private String shipping_method;
+        private String shipping_method;
+
+        // Shopify fulfillment metadata
+        private String fulfillmentOrderId;
+        private String fulfillmentLineItemId;
+        private Integer fulfillmentLineItemQty;
 
 	@NotNull(message = "created_at Es un campo requerido")
     @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
@@ -109,12 +114,36 @@ public class OrderDto {
 	public String getShipping_method() {
 		return shipping_method;
 	}
-	public void setShipping_method(String shipping_method) {
-		this.shipping_method = shipping_method;
-	}
-	public Date getCreated_at() {
-		return created_at;
-	}
+        public void setShipping_method(String shipping_method) {
+                this.shipping_method = shipping_method;
+        }
+
+        public String getFulfillmentOrderId() {
+                return fulfillmentOrderId;
+        }
+
+        public void setFulfillmentOrderId(String fulfillmentOrderId) {
+                this.fulfillmentOrderId = fulfillmentOrderId;
+        }
+
+        public String getFulfillmentLineItemId() {
+                return fulfillmentLineItemId;
+        }
+
+        public void setFulfillmentLineItemId(String fulfillmentLineItemId) {
+                this.fulfillmentLineItemId = fulfillmentLineItemId;
+        }
+
+        public Integer getFulfillmentLineItemQty() {
+                return fulfillmentLineItemQty;
+        }
+
+        public void setFulfillmentLineItemQty(Integer fulfillmentLineItemQty) {
+                this.fulfillmentLineItemQty = fulfillmentLineItemQty;
+        }
+        public Date getCreated_at() {
+                return created_at;
+        }
 	public void setCreated_at(Date created_at) {
 		this.created_at = created_at;
 	}

--- a/backend/src/main/java/com/rocket/service/model/ShopifyFulfillmentData.java
+++ b/backend/src/main/java/com/rocket/service/model/ShopifyFulfillmentData.java
@@ -1,0 +1,39 @@
+package com.rocket.service.model;
+
+public class ShopifyFulfillmentData {
+    private String fulfillmentOrderId;
+    private String lineItemId;
+    private Integer quantity;
+
+    public ShopifyFulfillmentData() {}
+
+    public ShopifyFulfillmentData(String fulfillmentOrderId, String lineItemId, Integer quantity) {
+        this.fulfillmentOrderId = fulfillmentOrderId;
+        this.lineItemId = lineItemId;
+        this.quantity = quantity;
+    }
+
+    public String getFulfillmentOrderId() {
+        return fulfillmentOrderId;
+    }
+
+    public void setFulfillmentOrderId(String fulfillmentOrderId) {
+        this.fulfillmentOrderId = fulfillmentOrderId;
+    }
+
+    public String getLineItemId() {
+        return lineItemId;
+    }
+
+    public void setLineItemId(String lineItemId) {
+        this.lineItemId = lineItemId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
+++ b/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.rocket.service.entity.VendorDto;
 
@@ -18,6 +19,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,5 +66,15 @@ class ShopifySyncServiceTest {
 
         verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
 
+    }
+
+    @Test
+    void testFetchFulfillmentDataCallsShopify() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(org.springframework.http.ResponseEntity.ok("{\"fulfillment_orders\":[{\"id\":1,\"line_items\":[{\"id\":2,\"quantity\":1}]}]}"));
+
+        service.fetchFulfillmentData(vendor, "123");
+
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
     }
 }


### PR DESCRIPTION
## Summary
- store Shopify fulfillment references in `OrderDto`
- expose new `ShopifyFulfillmentData` model
- add API call in `ShopifySyncService` to fetch fulfillment order data
- trigger fulfillment order retrieval when accepting an agenda
- extend unit tests for new service method

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6870e31d4798832384e8505405f41d3e