### PR TITLE
Integrate fulfillment ID storage

### DIFF
--- a/backend/src/main/java/com/rocket/service/controller/EstatusController.java
+++ b/backend/src/main/java/com/rocket/service/controller/EstatusController.java
@@ -125,8 +125,14 @@ public class EstatusController {
         if (response.getOrder() != null && response.getOrder().isShopifyOrder()) {
             VendorDto vendor = getVendor(response);
             if (vendor != null) {
-                shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
-                shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
+                String fid = null;
+                if (response.getOrder().getFulfillmentOrderId() != null) {
+                    fid = shopifySyncService.createFulfillmentWithTracking(vendor, response.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                    registroService.guardar(response);
+                } else {
+                    shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
+                }
+                shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
             }
         }
 
@@ -177,8 +183,14 @@ public class EstatusController {
             if (response.getOrder() != null && response.getOrder().isShopifyOrder()) {
                 VendorDto vendor = getVendor(response);
                 if (vendor != null) {
-                    shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
-                    shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
+                    String fid = null;
+                    if (response.getOrder().getFulfillmentOrderId() != null) {
+                        fid = shopifySyncService.createFulfillmentWithTracking(vendor, response.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                        registroService.guardar(response);
+                    } else {
+                        shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
+                    }
+                    shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
                 }
             }
         });
@@ -244,8 +256,14 @@ public class EstatusController {
                     if (response.getOrder() != null && response.getOrder().isShopifyOrder()) {
                         VendorDto vendor = getVendor(response);
                         if (vendor != null) {
-                            shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
-                            shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
+                    String fid = null;
+                    if (response.getOrder().getFulfillmentOrderId() != null) {
+                        fid = shopifySyncService.createFulfillmentWithTracking(vendor, response.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                        registroService.guardar(response);
+                    } else {
+                        shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
+                    }
+                    shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
                         }
                     }
 
@@ -342,8 +360,14 @@ public class EstatusController {
                 if (registro.getOrder() != null && registro.getOrder().isShopifyOrder()) {
                     VendorDto vendor = getVendor(registro);
                     if (vendor != null) {
+                    String fid = null;
+                    if (registro.getOrder().getFulfillmentOrderId() != null) {
+                        fid = shopifySyncService.createFulfillmentWithTracking(vendor, registro.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                        registroService.guardar(registro);
+                    } else {
                         shopifySyncService.createFulfillment(vendor, registro.getOrder().getId());
-                        shopifySyncService.postFulfillmentEvent(vendor, registro.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(registro.getIdEstatus()).getDesc());
+                    }
+                    shopifySyncService.postFulfillmentEvent(vendor, registro.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(registro.getIdEstatus()).getDesc());
                     }
                 }
 
@@ -370,8 +394,14 @@ public class EstatusController {
                 if (response.getOrder() != null && response.getOrder().isShopifyOrder()) {
                     VendorDto vendor = getVendor(response);
                     if (vendor != null) {
+                    String fid = null;
+                    if (response.getOrder().getFulfillmentOrderId() != null) {
+                        fid = shopifySyncService.createFulfillmentWithTracking(vendor, response.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                        registroService.guardar(response);
+                    } else {
                         shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
-                        shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
+                    }
+                    shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
                     }
                 }
 
@@ -450,8 +480,14 @@ public class EstatusController {
         if (response.getOrder() != null && response.getOrder().isShopifyOrder()) {
             VendorDto vendor = getVendor(response);
             if (vendor != null) {
-                shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
-                shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
+                String fid = null;
+                if (response.getOrder().getFulfillmentOrderId() != null) {
+                    fid = shopifySyncService.createFulfillmentWithTracking(vendor, response.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                    registroService.guardar(response);
+                } else {
+                    shopifySyncService.createFulfillment(vendor, response.getOrder().getId());
+                }
+                shopifySyncService.postFulfillmentEvent(vendor, response.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(response.getIdEstatus()).getDesc());
             }
         }
 
@@ -500,8 +536,14 @@ public class EstatusController {
                 if (r.getOrder() != null && r.getOrder().isShopifyOrder()) {
                     VendorDto vendor = getVendor(r);
                     if (vendor != null) {
-                        shopifySyncService.createFulfillment(vendor, r.getOrder().getId());
-                        shopifySyncService.postFulfillmentEvent(vendor, r.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(r.getIdEstatus()).getDesc());
+                        String fid = null;
+                        if (r.getOrder().getFulfillmentOrderId() != null) {
+                            fid = shopifySyncService.createFulfillmentWithTracking(vendor, r.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                            registroService.guardar(r);
+                        } else {
+                            shopifySyncService.createFulfillment(vendor, r.getOrder().getId());
+                        }
+                        shopifySyncService.postFulfillmentEvent(vendor, r.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(r.getIdEstatus()).getDesc());
                     }
                 }
             } catch (Exception e) {
@@ -550,8 +592,14 @@ public class EstatusController {
                 if (r.getOrder() != null && r.getOrder().isShopifyOrder()) {
                     VendorDto vendor = getVendor(r);
                     if (vendor != null) {
-                        shopifySyncService.createFulfillment(vendor, r.getOrder().getId());
-                        shopifySyncService.postFulfillmentEvent(vendor, r.getOrder().getId(), "0", estatusService.obtenerEstatusPorId(r.getIdEstatus()).getDesc());
+                        String fid = null;
+                        if (r.getOrder().getFulfillmentOrderId() != null) {
+                            fid = shopifySyncService.createFulfillmentWithTracking(vendor, r.getOrder(), "https://main.d3je47rbud1pwk.amplifyapp.com");
+                            registroService.guardar(r);
+                        } else {
+                            shopifySyncService.createFulfillment(vendor, r.getOrder().getId());
+                        }
+                        shopifySyncService.postFulfillmentEvent(vendor, r.getOrder().getId(), fid != null ? fid : "0", estatusService.obtenerEstatusPorId(r.getIdEstatus()).getDesc());
                     }
                 }
             } catch (Exception e) {

--- a/backend/src/main/java/com/rocket/service/entity/OrderDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/OrderDto.java
@@ -34,7 +34,13 @@ public class OrderDto {
 	// @NotEmpty es incorrecto para double. Si se requiere que no sea cero, usar @Min(0) o validación lógica.
 	private double shipping;
 	// @NotEmpty(message = "shipping_method es un campo requerido") // Puede ser vacío si no hay shipping lines
-	private String shipping_method;
+        private String shipping_method;
+
+        // Shopify fulfillment metadata
+        private String fulfillmentOrderId;
+        private String fulfillmentLineItemId;
+        private Integer fulfillmentLineItemQty;
+        private String fulfillmentId; // id devuelto al crear el fulfillment
 
 	@NotNull(message = "created_at Es un campo requerido")
     @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
@@ -109,12 +115,44 @@ public class OrderDto {
 	public String getShipping_method() {
 		return shipping_method;
 	}
-	public void setShipping_method(String shipping_method) {
-		this.shipping_method = shipping_method;
-	}
-	public Date getCreated_at() {
-		return created_at;
-	}
+        public void setShipping_method(String shipping_method) {
+                this.shipping_method = shipping_method;
+        }
+
+        public String getFulfillmentOrderId() {
+                return fulfillmentOrderId;
+        }
+
+        public void setFulfillmentOrderId(String fulfillmentOrderId) {
+                this.fulfillmentOrderId = fulfillmentOrderId;
+        }
+
+        public String getFulfillmentLineItemId() {
+                return fulfillmentLineItemId;
+        }
+
+        public void setFulfillmentLineItemId(String fulfillmentLineItemId) {
+                this.fulfillmentLineItemId = fulfillmentLineItemId;
+        }
+
+        public Integer getFulfillmentLineItemQty() {
+                return fulfillmentLineItemQty;
+        }
+
+        public void setFulfillmentLineItemQty(Integer fulfillmentLineItemQty) {
+                this.fulfillmentLineItemQty = fulfillmentLineItemQty;
+        }
+
+        public String getFulfillmentId() {
+                return fulfillmentId;
+        }
+
+        public void setFulfillmentId(String fulfillmentId) {
+                this.fulfillmentId = fulfillmentId;
+        }
+        public Date getCreated_at() {
+                return created_at;
+        }
 	public void setCreated_at(Date created_at) {
 		this.created_at = created_at;
 	}

--- a/backend/src/main/java/com/rocket/service/model/ShopifyFulfillmentData.java
+++ b/backend/src/main/java/com/rocket/service/model/ShopifyFulfillmentData.java
@@ -1,0 +1,39 @@
+package com.rocket.service.model;
+
+public class ShopifyFulfillmentData {
+    private String fulfillmentOrderId;
+    private String lineItemId;
+    private Integer quantity;
+
+    public ShopifyFulfillmentData() {}
+
+    public ShopifyFulfillmentData(String fulfillmentOrderId, String lineItemId, Integer quantity) {
+        this.fulfillmentOrderId = fulfillmentOrderId;
+        this.lineItemId = lineItemId;
+        this.quantity = quantity;
+    }
+
+    public String getFulfillmentOrderId() {
+        return fulfillmentOrderId;
+    }
+
+    public void setFulfillmentOrderId(String fulfillmentOrderId) {
+        this.fulfillmentOrderId = fulfillmentOrderId;
+    }
+
+    public String getLineItemId() {
+        return lineItemId;
+    }
+
+    public void setLineItemId(String lineItemId) {
+        this.lineItemId = lineItemId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/backend/src/main/java/com/rocket/service/service/ShopifySyncService.java
+++ b/backend/src/main/java/com/rocket/service/service/ShopifySyncService.java
@@ -4,7 +4,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import com.rocket.service.entity.VendorDto;
+import com.rocket.service.entity.OrderDto;
+import com.rocket.service.model.ShopifyFulfillmentData;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,5 +86,82 @@ public class ShopifySyncService {
         body.put("event", event);
         log.debug("Calling Shopify fulfillment event: {}", url);
         restTemplate.postForEntity(url, new HttpEntity<>(body, defaultHeaders(vendor)), String.class);
+    }
+
+    public ShopifyFulfillmentData fetchFulfillmentData(VendorDto vendor, String orderId) {
+        String url = baseUrl(vendor) + "/orders/" + orderId + "/fulfillment_orders.json";
+        log.debug("Fetching Shopify fulfillment data: {}", url);
+        String response = restTemplate.exchange(url, org.springframework.http.HttpMethod.GET,
+                new HttpEntity<>(defaultHeaders(vendor)), String.class).getBody();
+        if (response == null) {
+            return null;
+        }
+        try {
+            JsonObject obj = JsonParser.parseString(response).getAsJsonObject();
+            JsonArray arr = obj.getAsJsonArray("fulfillment_orders");
+            if (arr != null && arr.size() > 0) {
+                JsonObject fo = arr.get(0).getAsJsonObject();
+                String fId = fo.get("id").getAsString();
+                JsonArray li = fo.getAsJsonArray("line_items");
+                if (li != null && li.size() > 0) {
+                    JsonObject item = li.get(0).getAsJsonObject();
+                    String liId = item.get("id").getAsString();
+                    int qty = item.get("quantity").getAsInt();
+                    return new ShopifyFulfillmentData(fId, liId, qty);
+                } else {
+                    return new ShopifyFulfillmentData(fId, null, null);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Shopify fulfillment data", e);
+        }
+        return null;
+    }
+
+    public String createFulfillmentWithTracking(VendorDto vendor, OrderDto order, String baseSiteUrl) {
+        String url = baseUrl(vendor) + "/fulfillments.json";
+
+        Map<String, Object> tracking = new HashMap<>();
+        String orderKey = order.getOrderKey() != null ? order.getOrderKey().toHexString() : order.getId();
+        tracking.put("number", orderKey);
+        tracking.put("company", "Rocket Courier");
+        tracking.put("url", baseSiteUrl + "/intranet/inicio?orderKey=" + orderKey);
+
+        Map<String, Object> lineItem = new HashMap<>();
+        lineItem.put("id", order.getFulfillmentLineItemId());
+        lineItem.put("quantity", order.getFulfillmentLineItemQty());
+
+        Map<String, Object> fo = new HashMap<>();
+        fo.put("fulfillment_order_id", order.getFulfillmentOrderId());
+        fo.put("fulfillment_order_line_items", Collections.singletonList(lineItem));
+
+        Map<String, Object> fulfillment = new HashMap<>();
+        fulfillment.put("notify_customer", true);
+        fulfillment.put("tracking_info", tracking);
+        fulfillment.put("line_items_by_fulfillment_order", Collections.singletonList(fo));
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("fulfillment", fulfillment);
+
+        log.debug("Calling Shopify create fulfillment with tracking: {}", url);
+        org.springframework.http.ResponseEntity<String> response = restTemplate.postForEntity(
+                url, new HttpEntity<>(body, defaultHeaders(vendor)), String.class);
+
+        String fulfillmentId = null;
+        String respBody = response.getBody();
+        if (respBody != null) {
+            try {
+                JsonObject obj = JsonParser.parseString(respBody).getAsJsonObject();
+                JsonObject fulfillmentResp = obj.getAsJsonObject("fulfillment");
+                if (fulfillmentResp != null && fulfillmentResp.has("id")) {
+                    fulfillmentId = fulfillmentResp.get("id").getAsString();
+                }
+            } catch (Exception e) {
+                log.error("Error parsing fulfillment creation response", e);
+            }
+        }
+
+        order.setFulfillmentId(fulfillmentId);
+        return fulfillmentId;
     }
 }

--- a/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
+++ b/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
@@ -1,13 +1,15 @@
 package com.rocket.service.service;
 
 import static org.mockito.ArgumentMatchers.any;
-
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.rocket.service.entity.VendorDto;
+import com.rocket.service.entity.OrderDto;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,5 +67,32 @@ class ShopifySyncServiceTest {
 
         verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
 
+    }
+
+    @Test
+    void testFetchFulfillmentDataCallsShopify() {
+        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(org.springframework.http.ResponseEntity.ok("{\"fulfillment_orders\":[{\"id\":1,\"line_items\":[{\"id\":2,\"quantity\":1}]}]}"));
+
+        service.fetchFulfillmentData(vendor, "123");
+
+        verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
+    }
+
+    @Test
+    void testCreateFulfillmentWithTrackingCallsShopify() {
+        OrderDto order = new OrderDto();
+        order.setId("123");
+        order.setFulfillmentOrderId("1");
+        order.setFulfillmentLineItemId("2");
+        order.setFulfillmentLineItemQty(1);
+        when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(org.springframework.http.ResponseEntity.ok("{\"fulfillment\":{\"id\":321}}"));
+
+        String result = service.createFulfillmentWithTracking(vendor, order, "https://example.com");
+
+        verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
+        assertEquals("321", result);
+        assertEquals("321", order.getFulfillmentId());
     }
 }


### PR DESCRIPTION
## Summary
- store fulfillment ID from Shopify
- persist ID and use for posting fulfillment events
- parse fulfillment creation response
- unit test for fulfillment ID parsing
- update tracking site URL used for fulfillment creation

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6870e31d4798832384e8505405f41d3e