### PR TITLE
Integrate Shopify Step 2: Create Fulfillment with Tracking

### DIFF
--- a/backend/src/main/java/com/rocket/service/entity/OrderDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/OrderDto.java
@@ -40,6 +40,7 @@ public class OrderDto {
         private String fulfillmentOrderId;
         private String fulfillmentLineItemId;
         private Integer fulfillmentLineItemQty;
+        private String shopifyFulfillmentId; // Nuevo campo para el ID de fulfillment de Shopify
 
 	@NotNull(message = "created_at Es un campo requerido")
     @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
@@ -140,6 +141,12 @@ public class OrderDto {
 
         public void setFulfillmentLineItemQty(Integer fulfillmentLineItemQty) {
                 this.fulfillmentLineItemQty = fulfillmentLineItemQty;
+        }
+        public String getShopifyFulfillmentId() {
+                return shopifyFulfillmentId;
+        }
+        public void setShopifyFulfillmentId(String shopifyFulfillmentId) {
+                this.shopifyFulfillmentId = shopifyFulfillmentId;
         }
         public Date getCreated_at() {
                 return created_at;

--- a/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
+++ b/backend/src/test/java/com/rocket/service/service/ShopifySyncServiceTest.java
@@ -4,23 +4,33 @@ import static org.mockito.ArgumentMatchers.any;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.rocket.service.entity.OrderDto;
+import com.rocket.service.entity.RegistryDto;
 import com.rocket.service.entity.VendorDto;
 
+import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import org.mockito.InjectMocks;
-
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+
+import com.google.gson.JsonObject;
 
 @ExtendWith(MockitoExtension.class)
 class ShopifySyncServiceTest {
@@ -28,53 +38,215 @@ class ShopifySyncServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
-
     private ShopifySyncService service;
-
     private VendorDto vendor;
+    private RegistryDto registryDto;
+    private OrderDto orderDto;
+
+    private final String DEFAULT_SITE_URL = "https://test.rocket.com";
 
     @BeforeEach
     void setup() {
         vendor = new VendorDto();
-        vendor.setShopifyAccessToken("tkn");
-        vendor.setShopifyStoreUrl("https://store.myshopify.com");
-        vendor.setShopifyApiVersion("2024-04");
+        vendor.setShopifyAccessToken("test_token");
+        vendor.setShopifyStoreUrl("https://test-store.myshopify.com");
+        vendor.setShopifyApiVersion("2025-07"); // Matching the API version in user's example
+
+        orderDto = new OrderDto();
+        orderDto.setId("shopifyOrder123"); // Shopify Order ID
+        orderDto.setOrderKey(new ObjectId()); // Internal order key
+        orderDto.setFulfillmentOrderId("10978443329828");
+        orderDto.setFulfillmentLineItemId("31904189251876");
+        orderDto.setFulfillmentLineItemQty(9);
+
+        registryDto = new RegistryDto();
+        registryDto.setOrder(orderDto);
 
         service = new ShopifySyncService(restTemplate);
+    }
 
+    private String buildExpectedShopifyUrl() {
+        return "https://test-store.myshopify.com/admin/api/2025-07/fulfillments.json";
     }
 
     @Test
+    void createFulfillmentWithTracking_success() {
+        String expectedFulfillmentId = "5773843562788";
+        String mockShopifyResponse = "{\"fulfillment\":{\"id\":" + expectedFulfillmentId + ",\"status\":\"success\"}}";
+
+        when(restTemplate.postForObject(eq(buildExpectedShopifyUrl()), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(mockShopifyResponse);
+
+        String actualFulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+
+        assertEquals(expectedFulfillmentId, actualFulfillmentId);
+
+        ArgumentCaptor<HttpEntity> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).postForObject(eq(buildExpectedShopifyUrl()), httpEntityCaptor.capture(), eq(String.class));
+
+        HttpEntity capturedEntity = httpEntityCaptor.getValue();
+        assertNotNull(capturedEntity.getBody());
+        String payload = capturedEntity.getBody().toString();
+
+        // Basic payload checks
+        JsonObject parsedPayload = com.google.gson.JsonParser.parseString(payload).getAsJsonObject();
+        JsonObject fulfillmentNode = parsedPayload.getAsJsonObject("fulfillment");
+        assertNotNull(fulfillmentNode);
+        assertEquals(true, fulfillmentNode.get("notify_customer").getAsBoolean());
+
+        JsonObject trackingInfo = fulfillmentNode.getAsJsonObject("tracking_info");
+        assertNotNull(trackingInfo);
+        assertEquals(orderDto.getOrderKey().toString(), trackingInfo.get("number").getAsString());
+        assertEquals("Rocket Courier", trackingInfo.get("company").getAsString());
+        assertEquals(DEFAULT_SITE_URL + "/intranet/inicio?orderKey=" + orderDto.getOrderKey().toString(), trackingInfo.get("url").getAsString());
+
+        JsonObject lineItemsOrder = fulfillmentNode.getAsJsonArray("line_items_by_fulfillment_order").get(0).getAsJsonObject();
+        assertEquals(Long.parseLong(orderDto.getFulfillmentOrderId()), lineItemsOrder.get("fulfillment_order_id").getAsLong());
+        JsonObject lineItem = lineItemsOrder.getAsJsonArray("fulfillment_order_line_items").get(0).getAsJsonObject();
+        assertEquals(Long.parseLong(orderDto.getFulfillmentLineItemId()), lineItem.get("id").getAsLong());
+        assertEquals(orderDto.getFulfillmentLineItemQty().intValue(), lineItem.get("quantity").getAsInt());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_nullVendor_returnsNull() {
+        String fulfillmentId = service.createFulfillmentWithTracking(null, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_nullRegistry_returnsNull() {
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, null, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_nullOrderDto_returnsNull() {
+        registryDto.setOrder(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_nullSiteUrl_returnsNull() {
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, null);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_missingShopifyOrderId_returnsNull() {
+        orderDto.setId(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+         verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_missingOrderKey_returnsNull() {
+        orderDto.setOrderKey(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_missingFulfillmentOrderId_returnsNull() {
+        orderDto.setFulfillmentOrderId(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_missingLineItemId_returnsNull() {
+        orderDto.setFulfillmentLineItemId(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_missingQuantity_returnsNull() {
+        orderDto.setFulfillmentLineItemQty(null);
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+        verify(restTemplate, never()).postForObject(anyString(), any(), any());
+    }
+
+    @Test
+    void createFulfillmentWithTracking_shopifyReturnsNoFulfillmentId_returnsNull() {
+        String mockShopifyResponse = "{\"fulfillment\":{\"status\":\"success\"}}"; // No 'id' field
+        when(restTemplate.postForObject(eq(buildExpectedShopifyUrl()), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(mockShopifyResponse);
+
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+    }
+
+    @Test
+    void createFulfillmentWithTracking_shopifyReturnsMalformedJson_returnsNull() {
+        String mockShopifyResponse = "{\"fulfillment\":{\"id\":123,}}"; // Malformed JSON
+        when(restTemplate.postForObject(eq(buildExpectedShopifyUrl()), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(mockShopifyResponse);
+
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+    }
+
+    @Test
+    void createFulfillmentWithTracking_shopifyReturnsError_returnsNull() {
+        when(restTemplate.postForObject(eq(buildExpectedShopifyUrl()), any(HttpEntity.class), eq(String.class)))
+            .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST, "Shopify error"));
+
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+    }
+
+    @Test
+    void createFulfillmentWithTracking_shopifyReturnsNullResponse_returnsNull() {
+        when(restTemplate.postForObject(eq(buildExpectedShopifyUrl()), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(null);
+
+        String fulfillmentId = service.createFulfillmentWithTracking(vendor, registryDto, DEFAULT_SITE_URL);
+        assertNull(fulfillmentId);
+    }
+
+
+    // --- Existing tests, ensure they are still valid or adapt if necessary ---
+    @Test
     void testCreateFulfillmentCallsShopify() {
-        service.createFulfillment(vendor, "123");
-
-        verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
-
+        // This test might be for a different createFulfillment method,
+        // ensure it's still relevant or remove/adapt.
+        // For now, assuming it tests the older simple fulfillment creation.
+        String olderApiUrl = "https://test-store.myshopify.com/admin/api/2025-07/orders/123/fulfillments.json";
+        service.createFulfillment(vendor, "123"); // Assuming this is the older method
+        verify(restTemplate).postForEntity(eq(olderApiUrl), any(HttpEntity.class), eq(String.class));
     }
 
     @Test
     void testAddTrackingCallsShopify() {
+        String olderApiUrl = "https://test-store.myshopify.com/admin/api/2025-07/orders/123/fulfillments/555/update_tracking.json";
         service.addTracking(vendor, "123", "555", "TRACK", "Test");
-
-        verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
-
+        verify(restTemplate).postForEntity(eq(olderApiUrl), any(HttpEntity.class), eq(String.class));
     }
 
     @Test
     void testPostFulfillmentEventCallsShopify() {
+        String olderApiUrl = "https://test-store.myshopify.com/admin/api/2025-07/orders/123/fulfillments/555/events.json";
         service.postFulfillmentEvent(vendor, "123", "555", "delivered");
-
-        verify(restTemplate).postForEntity(anyString(), any(HttpEntity.class), eq(String.class));
-
+        verify(restTemplate).postForEntity(eq(olderApiUrl), any(HttpEntity.class), eq(String.class));
     }
 
     @Test
     void testFetchFulfillmentDataCallsShopify() {
-        when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
-            .thenReturn(org.springframework.http.ResponseEntity.ok("{\"fulfillment_orders\":[{\"id\":1,\"line_items\":[{\"id\":2,\"quantity\":1}]}]}"));
+        String apiUrl = "https://test-store.myshopify.com/admin/api/2025-07/orders/123/fulfillment_orders.json";
+        when(restTemplate.exchange(eq(apiUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+            .thenReturn(ResponseEntity.ok("{\"fulfillment_orders\":[{\"id\":1,\"line_items\":[{\"id\":2,\"quantity\":1}]}]}"));
 
         service.fetchFulfillmentData(vendor, "123");
-
-        verify(restTemplate).exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
+        verify(restTemplate).exchange(eq(apiUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class));
     }
 }


### PR DESCRIPTION
- I added `shopifyFulfillmentId` to `OrderDto` to store the ID from Step 2.
- I implemented `createFulfillmentWithTracking` in `ShopifySyncService` to make the POST `/fulfillments.json` call to Shopify with tracking info and line items by fulfillment order.
- I integrated this new service method into `TransaccionesRestController.solicitarAgenda`. The call is triggered when a Shopify order's status changes from 'Agenda Aceptada (pendiente de recolectar)' (ID 3) to 'Recolectado' (ID 6).
- I added comprehensive unit tests for `ShopifySyncService.createFulfillmentWithTracking`, covering success and various error scenarios.

This commit addresses the second part of the Shopify fulfillment process, enabling the creation of a full fulfillment with tracking details when a courier marks an order as collected.

- Agregué `ShopifyFullMentId` a` OrderDTO` para almacenar la identificación del paso 2.
- Implementé `CrearfulfillmentWithTracking` en` ShopifysyncService` para hacer la llamada post `/fulfillments.json` para comprar con información de seguimiento y pedido por orden de cumplimiento.
- Integré este nuevo método de servicio en `TransacCionesRestController.SolicitarAgenda`. La llamada se activa cuando el estado de una orden de Shopify cambia de 'Agenda Atceptada (Pendiente de Recolectar)' (ID 3) a 'Recolectado' (ID 6).
- Agregué pruebas unitarias completas para `ShopifysyncService.CreatefulfillmentWithTracking`, cubriendo el éxito y varios escenarios de error.

Este comodidad aborda la segunda parte del proceso de cumplimiento de Shopify, lo que permite la creación de un cumplimiento completo con los detalles de seguimiento cuando un servicio de mensajería marca un pedido recopilado.