### PR TITLE
fix: Handle null vendor in ShopifySyncService dispatchers

### DIFF
--- a/backend/src/main/java/com/rocket/service/service/ShopifySyncService.java
+++ b/backend/src/main/java/com/rocket/service/service/ShopifySyncService.java
@@ -197,6 +197,10 @@ public class ShopifySyncService {
     }
 
     public ShopifyFulfillmentData fetchFulfillmentData(VendorDto vendor, String shopifyOrderId, OrderDto orderDto) {
+        if (vendor == null) {
+            log.warn("Vendor es nulo, no se puede ejecutar fetchFulfillmentData.");
+            return null;
+        }
         if (vendor.isUseGraphQL()) {
             log.info("Dispatching to GraphQL implementation for fetchFulfillmentData.");
             return fetchFulfillmentDataGraphQL(vendor, shopifyOrderId, orderDto);
@@ -368,6 +372,10 @@ public class ShopifySyncService {
     }
 
     public String createFulfillmentWithTracking(VendorDto vendor, RegistryDto registryDto, String siteUrl) {
+        if (vendor == null) {
+            log.warn("Vendor es nulo, no se puede ejecutar createFulfillmentWithTracking.");
+            return null;
+        }
         if (vendor.isUseGraphQL()) {
             log.info("Dispatching to GraphQL implementation for createFulfillmentWithTracking.");
             return createFulfillmentWithTrackingGraphQL(vendor, registryDto, siteUrl);
@@ -462,6 +470,10 @@ public class ShopifySyncService {
     }
 
     public void postFulfillmentEvent(VendorDto vendor, OrderDto orderDto, String shopifyFulfillmentId, String eventStatus, String message) {
+        if (vendor == null) {
+            log.warn("Vendor es nulo, no se puede ejecutar postFulfillmentEvent.");
+            return;
+        }
         if (vendor.isUseGraphQL()) {
             log.info("Dispatching to GraphQL implementation for postFulfillmentEvent.");
             postFulfillmentEventGraphQL(vendor, orderDto, eventStatus, message);


### PR DESCRIPTION
- Added null checks for the `vendor` parameter at the beginning of the public dispatcher methods (`fetchFulfillmentData`, `createFulfillmentWithTracking`, `postFulfillmentEvent`).
- This prevents NullPointerExceptions when the methods are called with a null vendor, which was causing test failures (e.g., `createFulfillmentWithTracking_nullVendor_returnsNull`).
- This change makes the dispatcher logic more robust and ensures that tests for null inputs pass as expected.