### PR TITLE
fix: Improve Shopify API error visibility in frontend

### DIFF
--- a/backend/src/main/java/com/rocket/service/entity/OrderDto.java
+++ b/backend/src/main/java/com/rocket/service/entity/OrderDto.java
@@ -47,6 +47,9 @@ public class OrderDto {
         private String shopifyLineItemGid;
         private String shopifyFulfillmentGid;
 
+        @org.springframework.data.annotation.Transient
+        private String shopifyApiError; // Campo transitorio para mensajes de error
+
 	@NotNull(message = "created_at Es un campo requerido")
     @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
 	private Date created_at;
@@ -173,6 +176,14 @@ public class OrderDto {
         }
         public void setShopifyFulfillmentGid(String shopifyFulfillmentGid) {
                 this.shopifyFulfillmentGid = shopifyFulfillmentGid;
+        }
+
+        public String getShopifyApiError() {
+            return shopifyApiError;
+        }
+
+        public void setShopifyApiError(String shopifyApiError) {
+            this.shopifyApiError = shopifyApiError;
         }
 
         public Date getCreated_at() {

--- a/backend/src/main/java/com/rocket/service/exception/ShopifyApiException.java
+++ b/backend/src/main/java/com/rocket/service/exception/ShopifyApiException.java
@@ -1,0 +1,11 @@
+package com.rocket.service.exception;
+
+public class ShopifyApiException extends RuntimeException {
+    public ShopifyApiException(String message) {
+        super(message);
+    }
+
+    public ShopifyApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
- Created a custom `ShopifyApiException` to wrap API errors.
- Modified `ShopifySyncService` GraphQL methods to throw this exception upon receiving an error from the Shopify API.
- Added a transient field `shopifyApiError` to `OrderDto` to temporarily hold error messages.
- Updated `TransaccionesRestController` to catch `ShopifyApiException`, store the error message in the transient field, and append this message to the `DBResponse` sent to you.
- This ensures that when a Shopify API call fails, the specific error message is now visible in the frontend, greatly improving debugging capabilities.