### PR TITLE
feat: make shipping zip optional in validation

### DIFF
--- a/backend/src/main/java/com/rocket/service/service/RegistroService.java
+++ b/backend/src/main/java/com/rocket/service/service/RegistroService.java
@@ -236,8 +236,8 @@ public class RegistroService {
             if (regis.getShipping_address().getProvince() == null || regis.getShipping_address().getProvince().trim().isEmpty()) {
                 mensaje.append("Shipping Province: es un campo requerido. ");
             }
-            if (regis.getShipping_address().getZip() == null || regis.getShipping_address().getZip().trim().isEmpty()) {
-                mensaje.append("Shipping Zip: es un campo requerido. ");
+            if (regis.getShipping_address().getZip() != null && regis.getShipping_address().getZip().trim().isEmpty()) {
+                mensaje.append("Shipping Zip: es opcional, pero si se proporciona no debe estar vacío. ");
             }
             if (regis.getShipping_address().getPhone() == null || regis.getShipping_address().getPhone().trim().isEmpty()) {
                 mensaje.append("Shipping Phone: es un campo requerido. ");


### PR DESCRIPTION
## Summary
- allow missing shipping zip by making it optional in validation

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f492f7cc8323bbecd4993964d029